### PR TITLE
Expose connection id to the responder application

### DIFF
--- a/hacspec/src/lib.rs
+++ b/hacspec/src/lib.rs
@@ -150,7 +150,7 @@ pub fn r_prepare_message_2(
     cred_r: &BytesMaxBuffer,
     cred_r_len: usize,
     r: &BytesP256ElemLen, // R's static private DH key
-) -> (EDHOCError, State, BytesMessage2) {
+) -> (EDHOCError, State, BytesMessage2, U8) {
     let State(
         mut current_state,
         mut y,
@@ -166,6 +166,7 @@ pub fn r_prepare_message_2(
 
     let mut error = EDHOCError::UnknownError;
     let mut message_2 = BytesMessage2::new();
+    let mut c_r = U8(0xffu8); // invalid c_r
 
     if current_state == EDHOCState::ProcessedMessage1 {
         // TODO generate ephemeral key pair
@@ -173,7 +174,7 @@ pub fn r_prepare_message_2(
         let g_y = G_Y;
 
         // FIXME generate a connection identifier to multiplex sessions
-        let c_r = C_R;
+        c_r = C_R;
 
         // compute TH_2
         let th_2 = compute_th_2(&G_Y, c_r, &h_message_1);
@@ -224,7 +225,7 @@ pub fn r_prepare_message_2(
         error = EDHOCError::WrongState;
     }
 
-    (error, state, message_2)
+    (error, state, message_2, c_r)
 }
 
 // FIXME fetch ID_CRED_I and CRED_I based on kid

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -90,7 +90,7 @@ mod hacspec {
 
         pub fn prepare_message_2(
             self: &mut HacspecEdhocResponder<'a>,
-        ) -> (EDHOCError, [u8; MESSAGE_2_LEN]) {
+        ) -> (EDHOCError, [u8; MESSAGE_2_LEN], u8) {
             // init hacspec structs for id_cred_r and cred_r
             let id_cred_r = BytesIdCred::from_hex(self.id_cred_r);
             let mut cred_r = BytesMaxBuffer::new();
@@ -100,7 +100,7 @@ mod hacspec {
             // init hacspec structs for R's public static DH key
             let r = BytesP256ElemLen::from_hex(self.r);
 
-            let (error, state, message_2) =
+            let (error, state, message_2, c_r) =
                 r_prepare_message_2(self.state, &id_cred_r, &cred_r, cred_r_len, &r);
             self.state = state;
 
@@ -109,7 +109,7 @@ mod hacspec {
                 message_2_native[i] = message_2[i].declassify();
             }
 
-            (error, message_2_native)
+            (error, message_2_native, c_r.declassify())
         }
 
         pub fn process_message_3(
@@ -545,8 +545,9 @@ mod test {
         let error = responder.process_message_1(&message_1);
         assert!(error == EdhocError::Success);
 
-        let (error, message_2) = responder.prepare_message_2();
+        let (error, message_2, c_r) = responder.prepare_message_2();
         assert!(error == EdhocError::Success);
+        assert!(c_r != 0xff);
         let (error, _c_r) = initiator.process_message_2(&message_2);
         assert!(error == EdhocError::Success);
 


### PR DESCRIPTION
This PR exposes the connection identifier selected by the EDHOC library to the responder application code, in order for it to be able to demultiplex protocol state at the CoAP level. 