### PR TITLE
mark edhoc-rs no_std

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(test), no_std)]
+
 #[cfg(feature = "hacspec-native")]
 pub use {
     edhoc_consts::*, edhoc_hacspec::State as EdhocState,


### PR DESCRIPTION
The crate itself doesn't use any std features, so mark it as such.