### PR TITLE
update hacspec/Cargo.toml deps

### DIFF
--- a/hacspec/Cargo.toml
+++ b/hacspec/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD"
 description = "EDHOC implementation"
 
 [dependencies]
-hacspec-lib = { git = "https://github.com/malishav/hacspec", branch="aesccm", default-features = false }
-edhoc-crypto = { path = "../crypto" }
+hacspec-lib = { version = "0.1.0-beta.1", default-features = false }
+edhoc-crypto = { path = "../crypto", default-features = false }
 edhoc-consts = { path = "../consts" }
 


### PR DESCRIPTION
- also use plain hacspec-lib "version", rely on Cargo `[patch]` to select malisa's aesccm branch. missed this one in #19 
- import edhoc-crypto with "default-features = false", edhoc-rs handles selecting a crypto backend