### PR TITLE
crypto: add psa backend (stubs!)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crypto",
   "crypto/edhoc-crypto-cc2538",
   "crypto/edhoc-crypto-hacspec",
+  "crypto/edhoc-crypto-psa",
   "examples/coap",
   "examples/edhoc-rs-no_std",
 ]
@@ -17,6 +18,7 @@ default-members = [
   "hacspec",
   "crypto",
   "crypto/edhoc-crypto-hacspec",
+  "crypto/edhoc-crypto-psa",
   "examples/coap",
 ]
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,7 +15,11 @@ edhoc-crypto-hacspec = { path = "./edhoc-crypto-hacspec", optional = true }
 # cc2538 hardware accelerated
 edhoc-crypto-cc2538 = { path = "./edhoc-crypto-cc2538", optional = true }
 
+# psa
+edhoc-crypto-psa = { path = "./edhoc-crypto-psa", optional = true }
+
 [features]
 default = [ "hacspec" ]
 hacspec = [ "edhoc-crypto-hacspec" ]
 cc2538 = [ "edhoc-crypto-cc2538" ]
+psa = [ "edhoc-crypto-psa" ]

--- a/crypto/edhoc-crypto-psa/Cargo.toml
+++ b/crypto/edhoc-crypto-psa/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "edhoc-crypto-psa"
+version = "0.1.0"
+edition = "2021"
+authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
+license = "BSD"
+description = "EDHOC crypto library PSA backend"
+
+[dependencies]
+edhoc-consts = { path = "../../consts" }
+hacspec-lib = { version = "0.1.0-beta.1", default-features = false, features = [ "alloc" ] }
+psa-crypto = { version = "0.9.2" }

--- a/crypto/edhoc-crypto-psa/src/lib.rs
+++ b/crypto/edhoc-crypto-psa/src/lib.rs
@@ -1,0 +1,72 @@
+#![no_std]
+
+use edhoc_consts::*;
+use hacspec_lib::*;
+
+pub fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
+    // use psa_crypto::operations::hash::hash_compute;
+    // use psa_crypto::types::algorithm::Hash;
+    // let hash_alg = Hash::Sha256;
+    // let mut hash: [u8; 16] = [0; 16];
+    // //no idea how to convert the types :/ (@kaspar030)
+    // let size = hash_compute(
+    //     hash_alg,
+    //     message,
+    //     &mut hash,
+    // )
+    // .unwrap();
+    // let output = BytesHashLen::from_seq(&hash);
+    let output = BytesHashLen::new();
+    // TODO
+    output
+}
+
+pub fn hkdf_expand(
+    prk: &BytesHashLen,
+    info: &BytesMaxInfoBuffer,
+    info_len: usize,
+    length: usize,
+) -> BytesMaxBuffer {
+    let mut output = BytesMaxBuffer::new();
+    // TODO
+    output
+}
+
+pub fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen {
+    let output = BytesHashLen::new();
+
+    // TODO
+
+    output
+}
+
+pub fn aes_ccm_encrypt_tag_8(
+    key: &BytesCcmKeyLen,
+    iv: &BytesCcmIvLen,
+    ad: &BytesEncStructureLen,
+    plaintext: &BytesPlaintext3,
+) -> BytesCiphertext3 {
+    let output = BytesCiphertext3::new();
+    // TODO
+    output
+}
+
+pub fn aes_ccm_decrypt_tag_8(
+    key: &BytesCcmKeyLen,
+    iv: &BytesCcmIvLen,
+    ad: &BytesEncStructureLen,
+    ciphertext: &BytesCiphertext3,
+) -> (EDHOCError, BytesPlaintext3) {
+    let (err, p3) = (EDHOCError::UnknownError, BytesPlaintext3::new());
+    // TODO
+
+    (err, p3)
+}
+pub fn p256_ecdh(
+    private_key: &BytesP256ElemLen,
+    public_key: &BytesP256ElemLen,
+) -> BytesP256ElemLen {
+    let secret = BytesP256ElemLen::new();
+    // TODO
+    secret
+}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -5,3 +5,6 @@ pub use edhoc_crypto_hacspec::*;
 
 #[cfg(feature = "cc2538")]
 pub use edhoc_crypto_cc2538::*;
+
+#[cfg(feature = "psa")]
+pub use edhoc_crypto_psa::*;

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,4 +18,5 @@ edhoc-consts = { path = "../consts" }
 default = ["hacspec-native"]
 hacspec-native = ["hacspec-lib/std", "edhoc-hacspec", "edhoc-crypto/hacspec"]
 hacspec-cc2538 = ["hacspec-lib/alloc", "edhoc-hacspec", "edhoc-crypto/cc2538"]
+hacspec-psa = ["hacspec-lib/alloc", "edhoc-hacspec", "edhoc-crypto/psa"]
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,6 +1,10 @@
 #![cfg_attr(not(test), no_std)]
 
-#[cfg(any(feature = "hacspec-native", feature = "hacspec-cc2538"))]
+#[cfg(any(
+    feature = "hacspec-native",
+    feature = "hacspec-cc2538",
+    feature = "hacspec-psa"
+))]
 pub use {
     edhoc_consts::*, edhoc_hacspec::State as EdhocState,
     hacspec::HacspecEdhocInitiator as EdhocInitiator,
@@ -19,7 +23,11 @@ mod edhoc;
 #[cfg(feature = "rust-native")]
 use edhoc::*;
 
-#[cfg(any(feature = "hacspec-native", feature = "hacspec-cc2538"))]
+#[cfg(any(
+    feature = "hacspec-native",
+    feature = "hacspec-cc2538",
+    feature = "hacspec-psa"
+))]
 mod hacspec {
     use edhoc_consts::*;
     use edhoc_hacspec::*;


### PR DESCRIPTION
This adds a edhoc-crypto-psa package to the build system.
The primitives are not implemented yet!

edhoc-rs can be tested with this backend with:

cargo test --package edhoc-rs --no-default-features --features "hacspec-psa"

... but it fails due to missing implementations.

This PR is based on https://github.com/openwsn-berkeley/edhoc-rs/pull/25, which should be reviewed and merged first.