### PR TITLE
Reduce workspace default members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,6 @@ members = [
 # tested on the host architecture
 default-members = [
   "lib",
-  "hacspec",
-  "crypto",
-  "crypto/edhoc-crypto-hacspec",
-  "crypto/edhoc-crypto-psa",
   "examples/coap",
 ]
 

--- a/examples/coap/Cargo.toml
+++ b/examples/coap/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-edhoc-rs = { path = "../../lib", features = [ "hacspec-native" ] }
+edhoc-rs = { path = "../../lib", default-features = false }
 coap = { version = "0.12" }
 coap-lite = { version = "0.9.1" }
+
+[features]
+default = [ "hacspec-native" ]
+hacspec-native = [ "edhoc-rs/hacspec-native" ]
+hacspec-psa = [ "edhoc-rs/hacspec-psa" ]


### PR DESCRIPTION
This reduces the workspace default members to lib/ and examples/coap.
That allows build-testing the available crypto backends for std builds.
(Fixes issue pointed out at https://github.com/openwsn-berkeley/edhoc-rs/pull/30#issuecomment-1311925707.)