### PR TITLE
ci: configure automated releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: New features
+      labels:
+        - "new feature"
+    - title: Bugs fixed
+      labels:
+        - "bug"
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -110,3 +110,24 @@ jobs:
 
     - name: Build example
       run: cd examples/edhoc-rs-no_std && cargo build --target="thumbv7em-none-eabihf" --no-default-features --features="${{ matrix.edhoc_lib }}-${{ matrix.crypto }}, rtt" --release
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build-edhoc-package, run-example-on-qemu, build-example-for-cortex-m4]
+    if: >-
+      github.event_name == 'push' &&
+      startsWith(github.event.ref, 'refs/tags')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      # TODO: add the fstar code once it is working on CI
+      # - name: Download artifacts
+      #   uses: actions/download-artifact@v3
+      #   with:
+      #     name: artifacts
+      #     path: ./artifacts
+      - name: Release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,8 @@ name: Build and test
 
 on:
   push:
+    branches: [main]
+    tags: 'REL-*'
   pull_request:
 
 env:


### PR DESCRIPTION
Automatically create releases (and release notes) from tags.

The only needed manual work is to create and push a git tag. For example:
```bash
git tag REL-0.1.0
git push origin REL-0.1.0
```

The above will generate a new release named `REL-0.1.0`.

**Note**: the tag must be pushed from the original repo, and not from a fork, as forks have restricted permissions.