### PR TITLE
Add ead processing mechanics

### DIFF
--- a/consts/Cargo.toml
+++ b/consts/Cargo.toml
@@ -13,3 +13,5 @@ hacspec-lib = { version = "0.1.0-beta.1", default-features = false, optional = t
 default = [ ]
 hacspec = [ "hacspec-lib/alloc" ]
 rust = [ ]
+ead-none = [ ]
+ead-zeroconf = [ ]

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -344,14 +344,14 @@ mod structs_ead_zeroconf {
     #[derive(Copy, Clone, Debug)]
     pub struct EADResponderZeroConfHandler {
         pub state: EADResponderZeroConfState,
-        pub process_ead1_cb: fn(EdhocMessageBuffer, EADResponderZeroConfState) -> (EdhocMessageBuffer, EADResponderZeroConfState),
+        pub process_ead1_cb: fn(EdhocMessageBuffer, EADResponderZeroConfState) -> EADResponderZeroConfState,
     }
 
     impl Default for EADResponderZeroConfHandler {
         fn default() -> Self {
             EADResponderZeroConfHandler {
                 state: EADResponderZeroConfState { label: EAD_ZEROCONF_LABEL, ead_state: EADResponderProtocolState::Start },
-                process_ead1_cb: |ead1, state| (ead1, state),
+                process_ead1_cb: |_ead1, state| state,
             }
         }
     }

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -232,6 +232,7 @@ mod hacspec {
     array!(BytesEad2, 0, U8);
     pub type BytesEad2New = EdhocMessageBufferHacspec;
     pub type BytesEad1 = EdhocMessageBufferHacspec;
+    pub type BytesEad3 = EdhocMessageBufferHacspec;
     array!(BytesIdCred, ID_CRED_LEN, U8);
     array!(BytesSuites, SUITES_LEN, U8);
     array!(BytesSupportedSuites, SUPPORTED_SUITES_LEN, U8);
@@ -315,8 +316,10 @@ mod structs_ead_zeroconf {
         // TODO: use a smaller buffer for EAD items (and check if hacspec-v2 supports `const generics`)
         pub prepare_ead_1_cb:
             fn(EADInitiatorZeroConfState) -> (EdhocMessageBuffer, EADInitiatorZeroConfState),
-        pub process_ead_2_cb:
-            fn(EdhocMessageBuffer, EADInitiatorZeroConfState) -> EADInitiatorZeroConfState,
+        pub process_ead_2_cb: fn(
+            EdhocMessageBuffer,
+            EADInitiatorZeroConfState,
+        ) -> (Result<(), ()>, EADInitiatorZeroConfState),
         pub prepare_ead_3_cb:
             fn(EADInitiatorZeroConfState) -> (EdhocMessageBuffer, EADInitiatorZeroConfState),
     }
@@ -329,7 +332,7 @@ mod structs_ead_zeroconf {
                     ead_state: EADInitiatorProtocolState::Start,
                 },
                 prepare_ead_1_cb: |state| (EdhocMessageBuffer::new(), state),
-                process_ead_2_cb: |_msg2, state| state,
+                process_ead_2_cb: |_msg2, state| (Ok(()), state),
                 prepare_ead_3_cb: |state| (EdhocMessageBuffer::new(), state),
             }
         }
@@ -359,8 +362,10 @@ mod structs_ead_zeroconf {
         ) -> (Result<(), ()>, EADResponderZeroConfState),
         pub prepare_ead_2_cb:
             fn(EADResponderZeroConfState) -> (EdhocMessageBuffer, EADResponderZeroConfState),
-        pub process_ead_3_cb:
-            fn(EdhocMessageBuffer, EADResponderZeroConfState) -> EADResponderZeroConfState,
+        pub process_ead_3_cb: fn(
+            EdhocMessageBuffer,
+            EADResponderZeroConfState,
+        ) -> (Result<(), ()>, EADResponderZeroConfState),
     }
 
     impl Default for EADResponderZeroConfHandler {
@@ -372,7 +377,7 @@ mod structs_ead_zeroconf {
                 },
                 process_ead_1_cb: |_ead_1, state| (Ok(()), state),
                 prepare_ead_2_cb: |state| (EdhocMessageBuffer::new(), state),
-                process_ead_3_cb: |_ead_3, state| state,
+                process_ead_3_cb: |_ead_3, state| (Ok(()), state),
             }
         }
     }
@@ -393,7 +398,8 @@ mod ead_none {
     pub struct EADInitiatorNoneHandler {
         pub state: EADNoneState,
         pub prepare_ead_1_cb: fn(EADNoneState) -> (EdhocMessageBuffer, EADNoneState),
-        pub process_ead_2_cb: fn(EdhocMessageBuffer, EADNoneState) -> EADNoneState,
+        pub process_ead_2_cb:
+            fn(EdhocMessageBuffer, EADNoneState) -> (Result<(), ()>, EADNoneState),
         pub prepare_ead_3_cb: fn(EADNoneState) -> (EdhocMessageBuffer, EADNoneState),
     }
 
@@ -402,7 +408,7 @@ mod ead_none {
             EADInitiatorNoneHandler {
                 state: EADNoneState,
                 prepare_ead_1_cb: |state| (EdhocMessageBuffer::new(), state),
-                process_ead_2_cb: |_ead_2, state| state,
+                process_ead_2_cb: |_ead_2, state| (Ok(()), state),
                 prepare_ead_3_cb: |state| (EdhocMessageBuffer::new(), state),
             }
         }
@@ -414,7 +420,8 @@ mod ead_none {
         pub process_ead_1_cb:
             fn(EdhocMessageBuffer, EADNoneState) -> (Result<(), ()>, EADNoneState),
         pub prepare_ead_2_cb: fn(EADNoneState) -> (EdhocMessageBuffer, EADNoneState),
-        pub process_ead_3_cb: fn(EdhocMessageBuffer, EADNoneState) -> EADNoneState,
+        pub process_ead_3_cb:
+            fn(EdhocMessageBuffer, EADNoneState) -> (Result<(), ()>, EADNoneState),
     }
 
     impl Default for EADResponderNoneHandler {
@@ -423,7 +430,7 @@ mod ead_none {
                 state: EADNoneState,
                 process_ead_1_cb: |_ead_1, state| (Ok(()), state),
                 prepare_ead_2_cb: |state| (EdhocMessageBuffer::new(), state),
-                process_ead_3_cb: |_ead_3, state| state,
+                process_ead_3_cb: |_ead_3, state| (Ok(()), state),
             }
         }
     }

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -8,6 +8,9 @@ pub use hacspec::*;
 #[cfg(feature = "rust")]
 pub use rust::*;
 
+#[cfg(feature = "ead-zeroconf")]
+pub use ead_zeroconf::*;
+
 mod common {
 
     #[derive(Default, PartialEq, Copy, Clone, Debug)]
@@ -158,6 +161,9 @@ mod hacspec {
     use super::common::*;
     use hacspec_lib::*;
 
+    #[cfg(feature = "ead-zeroconf")]
+    use super::ead_zeroconf::*;
+
     array!(BytesMessageBuffer, MAX_MESSAGE_SIZE_LEN, U8);
 
     #[derive(Debug)]
@@ -263,5 +269,64 @@ mod hacspec {
         pub BytesHashLen,     // prk_exporter
         pub BytesHashLen,     // h_message_1
         pub BytesHashLen,     // th_3
+        #[cfg(feature = "ead-zeroconf")]
+        pub Option<EADInitiatorZeroConfHandler>,
+        #[cfg(feature = "ead-none")]
+        pub Option<EADInitiatorNoneHandler>,
     );
+
+}
+
+#[cfg(feature = "ead-zeroconf")]
+mod ead_zeroconf {
+    use super::common::*;
+
+    #[derive(Copy, Clone, Debug)]
+    pub struct EADInitiatorZeroConfState {
+        pub foo: u8,
+    }
+
+    #[derive(Copy, Clone, Debug)]
+    pub struct EADInitiatorZeroConfHandler {
+        pub label: u8,
+        pub state: EADInitiatorZeroConfState,
+        pub prepare_ead1_cb: fn(EdhocMessageBuffer, EADInitiatorZeroConfState) -> (EdhocMessageBuffer, EADInitiatorZeroConfState),
+    }
+
+    impl Default for EADInitiatorZeroConfHandler {
+        fn default() -> Self {
+            EADInitiatorZeroConfHandler {
+                label: 0,
+                state: EADInitiatorZeroConfState { foo: 0 },
+                prepare_ead1_cb: |ead1, state| (ead1, state),
+            }
+        }
+    }
+}
+
+#[cfg(feature = "ead-none")]
+mod ead_none {
+    use super::common::*;
+
+    #[derive(Copy, Clone, Debug)]
+    pub struct EADInitiatorNoneState {
+        pub foo: u8,
+    }
+
+    #[derive(Copy, Clone, Debug)]
+    pub struct EADInitiatorZeroConfHandler {
+        pub label: u8,
+        pub state: EADInitiatorNoneState,
+        pub prepare_ead1_cb: fn(EdhocMessageBuffer, EADInitiatorNoneState) -> (EdhocMessageBuffer, EADInitiatorNoneState),
+    }
+
+    impl Default for EADInitiatorZeroConfHandler {
+        fn default() -> Self {
+            EADInitiatorZeroConfHandler {
+                label: 0,
+                state: EADInitiatorNoneState { foo: 0 },
+                prepare_ead1_cb: |ead1, state| (ead1, state),
+            }
+        }
+    }
 }

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -11,6 +11,9 @@ pub use rust::*;
 #[cfg(feature = "ead-zeroconf")]
 pub use ead_zeroconf::*;
 
+#[cfg(feature = "ead-none")]
+pub use ead_none::*;
+
 mod common {
 
     #[derive(Default, PartialEq, Copy, Clone, Debug)]
@@ -164,6 +167,9 @@ mod hacspec {
     #[cfg(feature = "ead-zeroconf")]
     use super::ead_zeroconf::*;
 
+    #[cfg(feature = "ead-none")]
+    use super::ead_none::*;
+
     array!(BytesMessageBuffer, MAX_MESSAGE_SIZE_LEN, U8);
 
     #[derive(Debug)]
@@ -309,22 +315,15 @@ mod ead_none {
     use super::common::*;
 
     #[derive(Copy, Clone, Debug)]
-    pub struct EADInitiatorNoneState {
-        pub foo: u8,
+    pub struct EADInitiatorNoneHandler {
+        pub state: u8,
+        pub prepare_ead1_cb: fn(EdhocMessageBuffer, u8) -> (EdhocMessageBuffer, u8),
     }
 
-    #[derive(Copy, Clone, Debug)]
-    pub struct EADInitiatorZeroConfHandler {
-        pub label: u8,
-        pub state: EADInitiatorNoneState,
-        pub prepare_ead1_cb: fn(EdhocMessageBuffer, EADInitiatorNoneState) -> (EdhocMessageBuffer, EADInitiatorNoneState),
-    }
-
-    impl Default for EADInitiatorZeroConfHandler {
+    impl Default for EADInitiatorNoneHandler {
         fn default() -> Self {
-            EADInitiatorZeroConfHandler {
-                label: 0,
-                state: EADInitiatorNoneState { foo: 0 },
+            EADInitiatorNoneHandler {
+                state: 0,
                 prepare_ead1_cb: |ead1, state| (ead1, state),
             }
         }

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -229,10 +229,10 @@ mod hacspec {
         }
     }
 
-    array!(BytesEad2, 0, U8);
-    pub type BytesEad2New = EdhocMessageBufferHacspec;
-    pub type BytesEad1 = EdhocMessageBufferHacspec;
-    pub type BytesEad3 = EdhocMessageBufferHacspec;
+    // TODO[ead]: have adjustable (smaller) length for these buffers
+    pub type BufferEad1 = EdhocMessageBufferHacspec;
+    pub type BufferEad2 = EdhocMessageBufferHacspec;
+    pub type BufferEad3 = EdhocMessageBufferHacspec;
     array!(BytesIdCred, ID_CRED_LEN, U8);
     array!(BytesSuites, SUITES_LEN, U8);
     array!(BytesSupportedSuites, SUPPORTED_SUITES_LEN, U8);
@@ -301,7 +301,7 @@ mod structs_ead_zeroconf {
         #[default]
         Start,
         WaitEAD2,
-        Completed, // TODO: check if it is really ok to consider Completed after processing EAD_2
+        Completed, // TODO[ead]: check if it is really ok to consider Completed after processing EAD_2
     }
 
     #[derive(Copy, Clone, Debug)]
@@ -313,7 +313,7 @@ mod structs_ead_zeroconf {
     #[derive(Copy, Clone, Debug)]
     pub struct EADInitiatorZeroConfHandler {
         pub state: EADInitiatorZeroConfState,
-        // TODO: use a smaller buffer for EAD items (and check if hacspec-v2 supports `const generics`)
+        // TODO[ead]: use a smaller buffer for EAD items (and check if hacspec-v2 supports `const generics`)
         pub prepare_ead_1_cb:
             fn(EADInitiatorZeroConfState) -> (EdhocMessageBuffer, EADInitiatorZeroConfState),
         pub process_ead_2_cb: fn(

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -36,7 +36,8 @@ mod common {
         UnsupportedCipherSuite = 4,
         ParsingError = 5,
         WrongState = 6,
-        UnknownError = 7,
+        EADHandlingFailed = 7,
+        UnknownError = 8,
     }
 
     #[derive(PartialEq, Debug)]
@@ -230,6 +231,7 @@ mod hacspec {
 
     array!(BytesEad2, 0, U8);
     pub type BytesEad2New = EdhocMessageBufferHacspec;
+    pub type BytesEad1 = EdhocMessageBufferHacspec;
     array!(BytesIdCred, ID_CRED_LEN, U8);
     array!(BytesSuites, SUITES_LEN, U8);
     array!(BytesSupportedSuites, SUPPORTED_SUITES_LEN, U8);
@@ -351,8 +353,10 @@ mod structs_ead_zeroconf {
     #[derive(Copy, Clone, Debug)]
     pub struct EADResponderZeroConfHandler {
         pub state: EADResponderZeroConfState,
-        pub process_ead_1_cb:
-            fn(EdhocMessageBuffer, EADResponderZeroConfState) -> EADResponderZeroConfState,
+        pub process_ead_1_cb: fn(
+            EdhocMessageBuffer,
+            EADResponderZeroConfState,
+        ) -> (Result<(), ()>, EADResponderZeroConfState),
         pub prepare_ead_2_cb:
             fn(EADResponderZeroConfState) -> (EdhocMessageBuffer, EADResponderZeroConfState),
         pub process_ead_3_cb:
@@ -366,7 +370,7 @@ mod structs_ead_zeroconf {
                     label: EAD_ZEROCONF_LABEL,
                     ead_state: EADResponderProtocolState::Start,
                 },
-                process_ead_1_cb: |_ead_1, state| state,
+                process_ead_1_cb: |_ead_1, state| (Ok(()), state),
                 prepare_ead_2_cb: |state| (EdhocMessageBuffer::new(), state),
                 process_ead_3_cb: |_ead_3, state| state,
             }
@@ -407,7 +411,8 @@ mod ead_none {
     #[derive(Copy, Clone, Debug)]
     pub struct EADResponderNoneHandler {
         pub state: EADNoneState,
-        pub process_ead_1_cb: fn(EdhocMessageBuffer, EADNoneState) -> EADNoneState,
+        pub process_ead_1_cb:
+            fn(EdhocMessageBuffer, EADNoneState) -> (Result<(), ()>, EADNoneState),
         pub prepare_ead_2_cb: fn(EADNoneState) -> (EdhocMessageBuffer, EADNoneState),
         pub process_ead_3_cb: fn(EdhocMessageBuffer, EADNoneState) -> EADNoneState,
     }
@@ -416,7 +421,7 @@ mod ead_none {
         fn default() -> Self {
             EADResponderNoneHandler {
                 state: EADNoneState,
-                process_ead_1_cb: |_ead_1, state| state,
+                process_ead_1_cb: |_ead_1, state| (Ok(()), state),
                 prepare_ead_2_cb: |state| (EdhocMessageBuffer::new(), state),
                 process_ead_3_cb: |_ead_3, state| state,
             }

--- a/hacspec/Cargo.toml
+++ b/hacspec/Cargo.toml
@@ -11,3 +11,7 @@ hacspec-lib = { version = "0.1.0-beta.1", default-features = false, features = [
 edhoc-crypto = { path = "../crypto", default-features = false }
 edhoc-consts = { path = "../consts" }
 
+[features]
+ead-none = [ ]
+ead-zeroconf = [ ]
+

--- a/hacspec/src/lib.rs
+++ b/hacspec/src/lib.rs
@@ -372,10 +372,10 @@ pub fn i_prepare_message_1(
             c_i,
         );
 
-        if let Some(mut ead_init_handler) = ead_init_handler {
-            let (message_1_public, state) = (ead_init_handler.prepare_ead1_cb)(message_1.to_public_buffer(), ead_init_handler.state);
+        if let Some(mut ead_handler) = ead_init_handler {
+            let (message_1_public, state) = (ead_handler.prepare_ead1_cb)(message_1.to_public_buffer(), ead_handler.state);
             message_1 = EdhocMessageBufferHacspec::from_public_buffer(&message_1_public);
-            ead_init_handler.state = state;
+            ead_init_handler.unwrap().state = state;
         }
 
         // hash message_1 here to avoid saving the whole message in the state
@@ -619,7 +619,10 @@ pub fn construct_state(
     prk_exporter: BytesHashLen,
     h_message_1: BytesHashLen,
     th_3: BytesHashLen,
+    #[cfg(feature = "ead-zeroconf")]
     ead_init_handler: Option<EADInitiatorZeroConfHandler>,
+    #[cfg(feature = "ead-none")]
+    ead_init_handler: Option<EADInitiatorNoneHandler>,
 ) -> State {
     State(
         state,

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -25,3 +25,5 @@ hacspec-cryptocell310 = ["hacspec-lib/alloc", "edhoc-hacspec", "edhoc-crypto/cry
 rust-psa = [ "edhoc-consts/rust", "edhoc-crypto/psa-rust" ]
 rust-psa-baremetal = [ "edhoc-crypto/psa-rust-baremetal", "edhoc-consts/rust" ]
 rust-cryptocell310 = [ "edhoc-consts/rust", "edhoc-crypto/cryptocell310-rust" ]
+ead-none = [ ]
+ead-zeroconf = [ ]

--- a/lib/src/ead_zeroconf.rs
+++ b/lib/src/ead_zeroconf.rs
@@ -6,18 +6,16 @@ pub mod ead_zeroconf_initiator {
     pub fn new_handler() -> EADInitiatorZeroConfHandler {
         EADInitiatorZeroConfHandler {
             prepare_ead1_cb: prepare_ead_1,
+            process_ead2_cb: process_ead_2,
             ..Default::default()
         }
     }
 
     pub fn prepare_ead_1(
         mut buffer: EdhocMessageBuffer,
-        mut state: EADInitiatorZeroConfState
+        mut state: EADInitiatorZeroConfState,
     ) -> (EdhocMessageBuffer, EADInitiatorZeroConfState) {
         // TODO: append the label to the buffer
-        // buffer.content[buffer.len] = state.label;
-        // buffer.len += 1;
-
         // TODO: build Voucher_Info (LOC_W, ENC_ID), and append it to the buffer
 
         state.ead_state = EADInitiatorProtocolState::WaitEAD2;
@@ -25,6 +23,17 @@ pub mod ead_zeroconf_initiator {
         (buffer, state)
     }
 
+    pub fn process_ead_2(
+        buffer: EdhocMessageBuffer,
+        mut state: EADInitiatorZeroConfState,
+    ) -> EADInitiatorZeroConfState {
+        // TODO: verify the label
+        // TODO: verify the voucher
+
+        state.ead_state = EADInitiatorProtocolState::Completed;
+
+        state
+    }
 }
 
 pub mod ead_zeroconf_responder {
@@ -33,14 +42,17 @@ pub mod ead_zeroconf_responder {
     pub fn new_handler() -> EADResponderZeroConfHandler {
         EADResponderZeroConfHandler {
             process_ead1_cb: process_ead_1,
+            prepare_ead2_cb: prepare_ead_2,
+            process_ead3_cb: process_ead_3,
             ..Default::default()
         }
     }
 
     pub fn process_ead_1(
         buffer: EdhocMessageBuffer,
-        mut state: EADResponderZeroConfState
+        mut state: EADResponderZeroConfState,
     ) -> EADResponderZeroConfState {
+        // TODO: verify the label
         // TODO: trigger the voucher request to W
 
         state.ead_state = EADResponderProtocolState::ProcessedEAD1;
@@ -48,4 +60,25 @@ pub mod ead_zeroconf_responder {
         state
     }
 
+    pub fn prepare_ead_2(
+        mut state: EADResponderZeroConfState,
+    ) -> (EdhocMessageBuffer, EADResponderZeroConfState) {
+        // TODO: append the label to the buffer
+        // TODO: append Voucher (H(message_1), CRED_V) to the buffer
+
+        state.ead_state = EADResponderProtocolState::WaitMessage3;
+
+        (EdhocMessageBuffer::new(), state)
+    }
+
+    pub fn process_ead_3(
+        buffer: EdhocMessageBuffer,
+        mut state: EADResponderZeroConfState,
+    ) -> EADResponderZeroConfState {
+        // TODO: maybe retrive CRED_U from a Credential Database
+
+        state.ead_state = EADResponderProtocolState::Completed;
+
+        state
+    }
 }

--- a/lib/src/ead_zeroconf.rs
+++ b/lib/src/ead_zeroconf.rs
@@ -16,8 +16,8 @@ pub mod ead_zeroconf_initiator {
     ) -> (EdhocMessageBuffer, EADInitiatorZeroConfState) {
         let mut ead_1 = EdhocMessageBuffer::new();
 
-        // add the label to the buffer
-        // since in this case it is critical, it is encoded as a CBOR negative integer
+        // add the label to the buffer, tagged as critical,
+        // which means encoding it as a negative value, i.e., -label
         ead_1.content[0] = CBOR_NEG_INT_RANGE_START + EAD_ZEROCONF_LABEL;
         ead_1.len = 1;
 
@@ -56,13 +56,13 @@ pub mod ead_zeroconf_responder {
     pub fn process_ead_1(
         buffer: EdhocMessageBuffer,
         mut state: EADResponderZeroConfState,
-    ) -> EADResponderZeroConfState {
-        // TODO: verify the label
+    ) -> (Result<(), ()>, EADResponderZeroConfState) {
+        // TODO: parse and verify the label
         // TODO: trigger the voucher request to W
 
         state.ead_state = EADResponderProtocolState::ProcessedEAD1;
 
-        state
+        (Ok(()), state)
     }
 
     pub fn prepare_ead_2(

--- a/lib/src/ead_zeroconf.rs
+++ b/lib/src/ead_zeroconf.rs
@@ -1,0 +1,47 @@
+#![no_std]
+
+pub mod ead_zeroconf_initiator {
+    use edhoc_consts::*;
+
+    pub fn new_handler() -> EADInitiatorZeroConfHandler {
+        EADInitiatorZeroConfHandler {
+            prepare_ead1_cb: prepare_ead_1,
+            ..Default::default()
+        }
+    }
+
+    pub fn prepare_ead_1(
+        mut buffer: EdhocMessageBuffer,
+        mut state: EADInitiatorZeroConfState
+    ) -> (EdhocMessageBuffer, EADInitiatorZeroConfState) {
+        // TODO: actually implement the zeroconf ead stuff
+        buffer.content[buffer.len] = state.label;
+        buffer.len += 1;
+        state.ead_state = EADInitiatorProtocolState::WaitEAD2;
+        (buffer, state)
+    }
+
+}
+
+pub mod ead_zeroconf_receiver {
+    use edhoc_consts::*;
+
+    pub fn new_handler() -> EADResponderZeroConfHandler {
+        EADResponderZeroConfHandler {
+            process_ead1_cb: process_ead_1,
+            ..Default::default()
+        }
+    }
+
+    pub fn process_ead_1(
+        mut buffer: EdhocMessageBuffer,
+        mut state: EADResponderZeroConfState
+    ) -> (EdhocMessageBuffer, EADResponderZeroConfState) {
+        // TODO: actually implement the zeroconf ead stuff
+        buffer.content[buffer.len] = state.label;
+        buffer.len += 1;
+        state.ead_state = EADResponderProtocolState::ProcessedEAD1;
+        (buffer, state)
+    }
+
+}

--- a/lib/src/ead_zeroconf.rs
+++ b/lib/src/ead_zeroconf.rs
@@ -29,7 +29,7 @@ pub mod ead_zeroconf_initiator {
     }
 
     pub fn process_ead_2(
-        buffer: EdhocMessageBuffer,
+        ead_2: EdhocMessageBuffer,
         mut state: EADInitiatorZeroConfState,
     ) -> (Result<(), ()>, EADInitiatorZeroConfState) {
         // TODO: verify the label
@@ -54,7 +54,7 @@ pub mod ead_zeroconf_responder {
     }
 
     pub fn process_ead_1(
-        buffer: EdhocMessageBuffer,
+        ead_1: EdhocMessageBuffer,
         mut state: EADResponderZeroConfState,
     ) -> (Result<(), ()>, EADResponderZeroConfState) {
         // TODO: parse and verify the label
@@ -84,7 +84,7 @@ pub mod ead_zeroconf_responder {
     }
 
     pub fn process_ead_3(
-        buffer: EdhocMessageBuffer,
+        ead_3: EdhocMessageBuffer,
         mut state: EADResponderZeroConfState,
     ) -> (Result<(), ()>, EADResponderZeroConfState) {
         // TODO: maybe retrive CRED_U from a Credential Database

--- a/lib/src/ead_zeroconf.rs
+++ b/lib/src/ead_zeroconf.rs
@@ -5,22 +5,27 @@ pub mod ead_zeroconf_initiator {
 
     pub fn new_handler() -> EADInitiatorZeroConfHandler {
         EADInitiatorZeroConfHandler {
-            prepare_ead1_cb: prepare_ead_1,
-            process_ead2_cb: process_ead_2,
+            prepare_ead_1_cb: prepare_ead_1,
+            process_ead_2_cb: process_ead_2,
             ..Default::default()
         }
     }
 
     pub fn prepare_ead_1(
-        mut buffer: EdhocMessageBuffer,
         mut state: EADInitiatorZeroConfState,
     ) -> (EdhocMessageBuffer, EADInitiatorZeroConfState) {
-        // TODO: append the label to the buffer
+        let mut ead_1 = EdhocMessageBuffer::new();
+
+        // add the label to the buffer
+        // since in this case it is critical, it is encoded as a CBOR negative integer
+        ead_1.content[0] = CBOR_NEG_INT_RANGE_START + EAD_ZEROCONF_LABEL;
+        ead_1.len = 1;
+
         // TODO: build Voucher_Info (LOC_W, ENC_ID), and append it to the buffer
 
         state.ead_state = EADInitiatorProtocolState::WaitEAD2;
 
-        (buffer, state)
+        (ead_1, state)
     }
 
     pub fn process_ead_2(
@@ -41,9 +46,9 @@ pub mod ead_zeroconf_responder {
 
     pub fn new_handler() -> EADResponderZeroConfHandler {
         EADResponderZeroConfHandler {
-            process_ead1_cb: process_ead_1,
-            prepare_ead2_cb: prepare_ead_2,
-            process_ead3_cb: process_ead_3,
+            process_ead_1_cb: process_ead_1,
+            prepare_ead_2_cb: prepare_ead_2,
+            process_ead_3_cb: process_ead_3,
             ..Default::default()
         }
     }

--- a/lib/src/ead_zeroconf.rs
+++ b/lib/src/ead_zeroconf.rs
@@ -31,13 +31,13 @@ pub mod ead_zeroconf_initiator {
     pub fn process_ead_2(
         buffer: EdhocMessageBuffer,
         mut state: EADInitiatorZeroConfState,
-    ) -> EADInitiatorZeroConfState {
+    ) -> (Result<(), ()>, EADInitiatorZeroConfState) {
         // TODO: verify the label
         // TODO: verify the voucher
 
         state.ead_state = EADInitiatorProtocolState::Completed;
 
-        state
+        (Ok(()), state)
     }
 }
 
@@ -68,22 +68,29 @@ pub mod ead_zeroconf_responder {
     pub fn prepare_ead_2(
         mut state: EADResponderZeroConfState,
     ) -> (EdhocMessageBuffer, EADResponderZeroConfState) {
-        // TODO: append the label to the buffer
+        let mut ead_2 = EdhocMessageBuffer::new();
+
+        // add the label to the buffer (non-critical)
+        ead_2.content[0] = EAD_ZEROCONF_LABEL;
+        ead_2.len = 1;
+
         // TODO: append Voucher (H(message_1), CRED_V) to the buffer
 
-        state.ead_state = EADResponderProtocolState::WaitMessage3;
+        // NOTE: see the note in lib.rs::test_ead
+        // state.ead_state = EADResponderProtocolState::WaitMessage3;
+        state.ead_state = EADResponderProtocolState::Completed;
 
-        (EdhocMessageBuffer::new(), state)
+        (ead_2, state)
     }
 
     pub fn process_ead_3(
         buffer: EdhocMessageBuffer,
         mut state: EADResponderZeroConfState,
-    ) -> EADResponderZeroConfState {
+    ) -> (Result<(), ()>, EADResponderZeroConfState) {
         // TODO: maybe retrive CRED_U from a Credential Database
 
         state.ead_state = EADResponderProtocolState::Completed;
 
-        state
+        (Ok(()), state)
     }
 }

--- a/lib/src/ead_zeroconf.rs
+++ b/lib/src/ead_zeroconf.rs
@@ -14,16 +14,20 @@ pub mod ead_zeroconf_initiator {
         mut buffer: EdhocMessageBuffer,
         mut state: EADInitiatorZeroConfState
     ) -> (EdhocMessageBuffer, EADInitiatorZeroConfState) {
-        // TODO: actually implement the zeroconf ead stuff
-        buffer.content[buffer.len] = state.label;
-        buffer.len += 1;
+        // TODO: append the label to the buffer
+        // buffer.content[buffer.len] = state.label;
+        // buffer.len += 1;
+
+        // TODO: build Voucher_Info (LOC_W, ENC_ID), and append it to the buffer
+
         state.ead_state = EADInitiatorProtocolState::WaitEAD2;
+
         (buffer, state)
     }
 
 }
 
-pub mod ead_zeroconf_receiver {
+pub mod ead_zeroconf_responder {
     use edhoc_consts::*;
 
     pub fn new_handler() -> EADResponderZeroConfHandler {
@@ -34,14 +38,14 @@ pub mod ead_zeroconf_receiver {
     }
 
     pub fn process_ead_1(
-        mut buffer: EdhocMessageBuffer,
+        buffer: EdhocMessageBuffer,
         mut state: EADResponderZeroConfState
-    ) -> (EdhocMessageBuffer, EADResponderZeroConfState) {
-        // TODO: actually implement the zeroconf ead stuff
-        buffer.content[buffer.len] = state.label;
-        buffer.len += 1;
+    ) -> EADResponderZeroConfState {
+        // TODO: trigger the voucher request to W
+
         state.ead_state = EADResponderProtocolState::ProcessedEAD1;
-        (buffer, state)
+
+        state
     }
 
 }

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -1058,13 +1058,13 @@ fn compute_mac_2(
 fn decode_plaintext_2(
     plaintext_2: &BytesMaxBuffer,
     plaintext_2_len: usize,
-) -> Result<(U8, BytesMac2, BytesEad2), EDHOCError> {
+) -> Result<(U8, BytesMac2, BufferEad2), EDHOCError> {
     let id_cred_r = plaintext_2[0];
     // skip cbor byte string byte as we know how long the string is
     let mut mac_2: BytesMac2 = [0x00; MAC_LENGTH_2];
     mac_2[..].copy_from_slice(&plaintext_2[2..2 + MAC_LENGTH_2]);
     // FIXME we don't support ead_2 parsing for now
-    let ead_2: BytesEad2 = [0x00; 0];
+    let ead_2: BufferEad2 = [0x00; 0];
 
     Ok((id_cred_r, mac_2, ead_2))
 }
@@ -1072,7 +1072,7 @@ fn decode_plaintext_2(
 fn encode_plaintext_2(
     id_cred_r: &BytesIdCred,
     mac_2: &BytesMac2,
-    ead_2: &BytesEad2,
+    ead_2: &BufferEad2,
 ) -> BufferPlaintext2 {
     let mut plaintext_2: BufferPlaintext2 = BufferPlaintext2::new();
     plaintext_2.content[0] = id_cred_r[id_cred_r.len() - 1];

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -717,17 +717,20 @@ mod test {
     #[cfg(feature = "ead-zeroconf")]
     #[test]
     fn test_ead_4() {
-        /// using ...
+        /// using ead = zeroconf
 
         fn i_prepare_ead_zeroconf(
-            buffer: EdhocMessageBuffer,
-            state: EADInitiatorZeroConfState
+            mut buffer: EdhocMessageBuffer,
+            mut state: EADInitiatorZeroConfState
         ) -> (EdhocMessageBuffer, EADInitiatorZeroConfState) {
             // ...
+            buffer.content[buffer.len] = 0xfe;
+            buffer.len += 1;
+            state.foo = 0x9;
             (buffer, state)
         }
 
-        let i_ead_zeroconf = EADInitiatorHandler {
+        let i_ead_zeroconf = EADInitiatorZeroConfHandler {
             label: 0,
             state: EADInitiatorZeroConfState { foo: 0x1 },
             prepare_ead1_cb: i_prepare_ead_zeroconf,
@@ -736,6 +739,19 @@ mod test {
         let mut initiator = EdhocInitiator::new(EdhocState::default(), I, G_R, ID_CRED_I, CRED_I, ID_CRED_R, CRED_R);
 
         initiator.register_ead_handler(i_ead_zeroconf);
+
+        let message_1 = initiator.prepare_message_1().unwrap();
+        assert_eq!(message_1.content[message_1.len-1], 0xfe);
+
+    }
+
+    #[cfg(feature = "ead-none")]
+    #[test]
+    fn test_ead_4() {
+        /// using ead = none
+        let mut initiator = EdhocInitiator::new(EdhocState::default(), I, G_R, ID_CRED_I, CRED_I, ID_CRED_R, CRED_R);
+        let message_1 = initiator.prepare_message_1().unwrap();
+        assert_eq!(message_1.content[message_1.len-1], 0x37);
     }
 
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -745,7 +745,7 @@ mod test {
         let (message_2, c_r) = responder.prepare_message_2().unwrap();
         assert_eq!(
             responder.get_state().11.unwrap().state.ead_state,
-            EADResponderProtocolState::WaitMessage3
+            EADResponderProtocolState::Completed
         );
 
         let _c_r = initiator.process_message_2(&message_2);
@@ -762,6 +762,13 @@ mod test {
 
         let r_prk_out = responder.process_message_3(&message_3);
         assert!(r_prk_out.is_ok());
+
+        // NOTE:
+        // - since lake-authz does not specify EAD_3, there is no processing of EAD_3 in the responder
+        // - this makes it difficult for V to know when to trigger the "credential lookup" procedure to obtain CRED_U
+        // - maybe the draft should be updated, so that a small EAD_3 is sent in message_3 (could be just the lake-authz
+        //   label, non-critical), so that V processes EAD_3 and then have an opportunity to trigger the credential lookup procedure
+
         assert_eq!(
             responder.get_state().11.unwrap().state.ead_state,
             EADResponderProtocolState::Completed

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -700,7 +700,7 @@ mod test {
 
     #[cfg(feature = "ead-zeroconf")]
     #[test]
-    fn test_ead_4() {
+    fn test_ead() {
         use ead_zeroconf::*;
 
         let state_initiator: EdhocState = Default::default();

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -103,7 +103,7 @@ mod hacspec {
             self: &mut HacspecEdhocResponder<'a>,
             ead_handler: EADResponderZeroConfHandler,
         ) {
-            self.state.11 = Some(ead_handler);
+            self.state.11 = Some(ead_handler); // TODO[ead]: improve after refactoring state to a named struct
         }
 
         #[cfg(test)]
@@ -234,7 +234,7 @@ mod hacspec {
             self: &mut HacspecEdhocInitiator<'a>,
             ead_handler: EADInitiatorZeroConfHandler,
         ) {
-            self.state.10 = Some(ead_handler);
+            self.state.10 = Some(ead_handler); // TODO[ead]: improve after refactoring state to a named struct
         }
 
         #[cfg(test)]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -701,7 +701,6 @@ mod test {
     #[cfg(feature = "ead-zeroconf")]
     #[test]
     fn test_ead_4() {
-        /// using ead = zeroconf
         use ead_zeroconf::*;
 
         let state_initiator: EdhocState = Default::default();
@@ -732,31 +731,40 @@ mod test {
         responder.register_ead_handler(r_zeroconf_handler);
 
         let message_1 = initiator.prepare_message_1().unwrap();
-        assert_eq!(initiator.get_state().10.unwrap().state.ead_state, EADInitiatorProtocolState::WaitEAD2);
+        assert_eq!(
+            initiator.get_state().10.unwrap().state.ead_state,
+            EADInitiatorProtocolState::WaitEAD2
+        );
 
         responder.process_message_1(&message_1).unwrap();
-        assert_eq!(responder.get_state().11.unwrap().state.ead_state, EADResponderProtocolState::ProcessedEAD1);
+        assert_eq!(
+            responder.get_state().11.unwrap().state.ead_state,
+            EADResponderProtocolState::ProcessedEAD1
+        );
 
-        // let (message_2, c_r) = responder.prepare_message_2().unwrap();
-        // assert_eq!(responder.get_state().11.unwrap().state.ead_state, EADResponderProtocolState::WaitMessage3);
+        let (message_2, c_r) = responder.prepare_message_2().unwrap();
+        assert_eq!(
+            responder.get_state().11.unwrap().state.ead_state,
+            EADResponderProtocolState::WaitMessage3
+        );
 
-        // let _c_r = initiator.process_message_2(&message_2);
+        let _c_r = initiator.process_message_2(&message_2);
+        assert_eq!(
+            initiator.get_state().10.unwrap().state.ead_state,
+            EADInitiatorProtocolState::Completed
+        );
 
-        // let (message_3, i_prk_out) = initiator.prepare_message_3().unwrap();
-        // assert!(ret.is_ok());
+        let (message_3, i_prk_out) = initiator.prepare_message_3().unwrap();
+        assert_eq!(
+            initiator.get_state().10.unwrap().state.ead_state,
+            EADInitiatorProtocolState::Completed
+        );
 
-        // let r_prk_out = responder.process_message_3(&message_3);
-        // assert!(r_prk_out.is_ok());
-
+        let r_prk_out = responder.process_message_3(&message_3);
+        assert!(r_prk_out.is_ok());
+        assert_eq!(
+            responder.get_state().11.unwrap().state.ead_state,
+            EADResponderProtocolState::Completed
+        );
     }
-
-    #[cfg(feature = "ead-none")]
-    #[test]
-    fn test_ead_4() {
-        /// using ead = none
-        let mut initiator = EdhocInitiator::new(EdhocState::default(), I, G_R, ID_CRED_I, CRED_I, ID_CRED_R, CRED_R);
-        let message_1 = initiator.prepare_message_1().unwrap();
-        assert_eq!(message_1.content[message_1.len-1], 0x37);
-    }
-
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -106,6 +106,11 @@ mod hacspec {
             self.state.11 = Some(ead_handler);
         }
 
+        #[cfg(test)]
+        pub fn get_state(self: &mut HacspecEdhocResponder<'a>) -> State {
+            self.state
+        }
+
         pub fn process_message_1(
             self: &mut HacspecEdhocResponder<'a>,
             message_1: &EdhocMessageBuffer,
@@ -723,12 +728,25 @@ mod test {
         let i_zeroconf_handler = ead_zeroconf_initiator::new_handler();
         initiator.register_ead_handler(i_zeroconf_handler);
 
-        let r_zeroconf_handler = ead_zeroconf_receiver::new_handler();
+        let r_zeroconf_handler = ead_zeroconf_responder::new_handler();
         responder.register_ead_handler(r_zeroconf_handler);
 
         let message_1 = initiator.prepare_message_1().unwrap();
-        assert_eq!(message_1.content[message_1.len-1], EAD_ZEROCONF_LABEL);
-        // assert_eq!(initiator.get_state().10.unwrap().state.ead_state, EADInitiatorProtocolState::WaitEAD2);
+        assert_eq!(initiator.get_state().10.unwrap().state.ead_state, EADInitiatorProtocolState::WaitEAD2);
+
+        responder.process_message_1(&message_1).unwrap();
+        assert_eq!(responder.get_state().11.unwrap().state.ead_state, EADResponderProtocolState::ProcessedEAD1);
+
+        // let (message_2, c_r) = responder.prepare_message_2().unwrap();
+        // assert_eq!(responder.get_state().11.unwrap().state.ead_state, EADResponderProtocolState::WaitMessage3);
+
+        // let _c_r = initiator.process_message_2(&message_2);
+
+        // let (message_3, i_prk_out) = initiator.prepare_message_3().unwrap();
+        // assert!(ret.is_ok());
+
+        // let r_prk_out = responder.process_message_3(&message_3);
+        // assert!(r_prk_out.is_ok());
 
     }
 


### PR DESCRIPTION
Work in progress.

- Introduces a new feature called `ead-zeroconf`, which enables the zero conf implementation
- For now at least, it also needs a `ead-none` feature, which is used when no EAD is to be used

How to test:

```
RUST_BACKTRACE=1 cargo test --no-default-features --package edhoc-rs --package edhoc-crypto --package edhoc-hacspec --package edhoc-consts --features="hacspec-psa, ead-zeroconf" --no-fail-fast test
```