### PR TITLE
Parse ead items

### DIFF
--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -110,6 +110,14 @@ mod common {
 mod rust {
     use super::common::*;
 
+    #[derive(Debug)]
+    pub struct EADItem {
+        pub label: u8,
+        pub is_critical: bool,
+        // TODO[ead]: have adjustable (smaller) length for this buffer
+        pub value: Option<EdhocMessageBuffer>,
+    }
+
     pub type U8 = u8;
     pub type BytesEad2 = [u8; 0];
     pub type BytesIdCred = [u8; ID_CRED_LEN];

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -93,6 +93,8 @@ mod common {
     pub const MAX_BUFFER_LEN: usize = 220;
     pub const CBOR_BYTE_STRING: u8 = 0x58u8;
     pub const CBOR_UINT_1BYTE: u8 = 0x18u8;
+    pub const CBOR_NEG_INT_1BYTE_START: u8 = 0x20u8;
+    pub const CBOR_NEG_INT_1BYTE_END: u8 = 0x37u8;
     pub const CBOR_MAJOR_TEXT_STRING: u8 = 0x60u8;
     pub const CBOR_MAJOR_BYTE_STRING: u8 = 0x40u8;
     pub const CBOR_MAJOR_ARRAY: u8 = 0x80u8;
@@ -212,17 +214,12 @@ mod hacspec {
 
     #[derive(Debug)]
     pub struct EADItem {
-        // FIXME: shouldn't the label _definition_ (thinking IANA level) be unsigned,
-        // and only possibly negative when CBOR-encoded to indicate criticality?
         pub label: u8,
         pub is_critical: bool,
+        // TODO[ead]: have adjustable (smaller) length for this buffer
         pub value: Option<EdhocMessageBufferHacspec>,
     }
 
-    // TODO[ead]: have adjustable (smaller) length for these buffers
-    pub type BufferEad1 = EdhocMessageBufferHacspec;
-    pub type BufferEad2 = EdhocMessageBufferHacspec;
-    pub type BufferEad3 = EdhocMessageBufferHacspec;
     array!(BytesIdCred, ID_CRED_LEN, U8);
     array!(BytesSuites, SUITES_LEN, U8);
     array!(BytesSupportedSuites, SUPPORTED_SUITES_LEN, U8);

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -210,7 +210,10 @@ mod hacspec {
         }
     }
 
-    array!(BytesEad2, 0, U8);
+    // TODO[ead]: have adjustable (smaller) length for these buffers
+    pub type BufferEad1 = EdhocMessageBufferHacspec;
+    pub type BufferEad2 = EdhocMessageBufferHacspec;
+    pub type BufferEad3 = EdhocMessageBufferHacspec;
     array!(BytesIdCred, ID_CRED_LEN, U8);
     array!(BytesSuites, SUITES_LEN, U8);
     array!(BytesSupportedSuites, SUPPORTED_SUITES_LEN, U8);

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -210,6 +210,18 @@ mod hacspec {
         }
     }
 
+    #[derive(Debug)]
+    pub struct BufferEAD {
+        pub label: i8,
+        pub value: EdhocMessageBufferHacspec,
+    }
+
+    impl BufferEAD {
+        pub fn is_critical(&self) -> bool {
+            self.label < 0
+        }
+    }
+
     // TODO[ead]: have adjustable (smaller) length for these buffers
     pub type BufferEad1 = EdhocMessageBufferHacspec;
     pub type BufferEad2 = EdhocMessageBufferHacspec;

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -211,12 +211,14 @@ mod hacspec {
     }
 
     #[derive(Debug)]
-    pub struct BufferEAD {
+    pub struct EADItem {
+        // FIXME: shouldn't the label _definition_ (thinking IANA level) be unsigned,
+        // and only possibly negative when CBOR-encoded to indicate criticality?
         pub label: i8,
-        pub value: EdhocMessageBufferHacspec,
+        pub value: Option<EdhocMessageBufferHacspec>,
     }
 
-    impl BufferEAD {
+    impl EADItem {
         pub fn is_critical(&self) -> bool {
             self.label < 0
         }

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -214,14 +214,9 @@ mod hacspec {
     pub struct EADItem {
         // FIXME: shouldn't the label _definition_ (thinking IANA level) be unsigned,
         // and only possibly negative when CBOR-encoded to indicate criticality?
-        pub label: i8,
+        pub label: u8,
+        pub is_critical: bool,
         pub value: Option<EdhocMessageBufferHacspec>,
-    }
-
-    impl EADItem {
-        pub fn is_critical(&self) -> bool {
-            self.label < 0
-        }
     }
 
     // TODO[ead]: have adjustable (smaller) length for these buffers


### PR DESCRIPTION
Parse and encode EAD items in messages 1, 2, and 3.

Implemented in hacspec version, ready for review. After the review I will bring the changes to the Rust version.