### PR TITLE
EAD mechanics using separate crate and enabled via features

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         edhoc_lib: [hacspec, rust]
         crypto: [hacspec, psa]
+        ead: [ead-none, ead-zeroconf]
         exclude:
           - edhoc_lib: rust
             crypto: hacspec
@@ -38,7 +39,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run unit tests # note that we only add `--package edhoc-hacspec` when testing the hacspec version of the lib
-      run: cargo test --no-default-features --package edhoc-rs --package edhoc-crypto ${{ matrix.edhoc_lib == 'hacspec' && '--package edhoc-hacspec' || '' }} --features="${{ matrix.edhoc_lib }}-${{ matrix.crypto }}" --no-fail-fast
+      run: cargo test --package edhoc-rs --package edhoc-crypto --package edhoc-ead ${{ matrix.edhoc_lib == 'hacspec' && '--package edhoc-hacspec' || '' }} --no-default-features --features="${{ matrix.edhoc_lib }}-${{ matrix.crypto }}, ${{ matrix.ead }}" --no-fail-fast
 
 
   build-edhoc-package:
@@ -50,6 +51,7 @@ jobs:
       matrix:
         edhoc_lib: [hacspec, rust]
         crypto: [hacspec, psa, psa-baremetal, cryptocell310]
+        ead: [ead-none, ead-zeroconf]
         exclude:
           - edhoc_lib: rust
             crypto: hacspec
@@ -64,7 +66,7 @@ jobs:
       run: sudo apt-get -y update && sudo apt-get -y install gcc-arm-none-eabi
 
     - name: Build
-      run: cargo build --package edhoc-rs --package edhoc-crypto --no-default-features --features="${{ matrix.edhoc_lib }}-${{ matrix.crypto }}" --release
+      run: cargo build --package edhoc-rs --package edhoc-crypto --package edhoc-ead --no-default-features --features="${{ matrix.edhoc_lib }}-${{ matrix.crypto }}, ${{ matrix.ead }}" --release
 
 
   run-example-on-qemu:
@@ -75,6 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         config: [hacspec-psa, rust-psa]
+        ead: [ead-none, ead-zeroconf]
 
     steps:
     - name: Checkout repo
@@ -88,7 +91,8 @@ jobs:
       run: sudo apt-get -y install qemu-system-arm
 
     - name: Run tests in QEMU
-      run: cd examples/edhoc-rs-no_std && cargo run --target="thumbv7m-none-eabi" --no-default-features --features="${{ matrix.config }}" --release
+      # FIXME: still failing
+      run: cd examples/edhoc-rs-no_std && cargo run --target="thumbv7m-none-eabi" --no-default-features --features="${{ matrix.config }}, ${{ matrix.ead }}" --release
 
 
   build-example-for-cortex-m4:
@@ -100,6 +104,7 @@ jobs:
       matrix:
         edhoc_lib: [hacspec, rust]
         crypto: [psa, cryptocell310]
+        ead: [ead-none, ead-zeroconf]
 
     steps:
     - name: Checkout repo
@@ -111,7 +116,8 @@ jobs:
       run: sudo apt-get -y update && sudo apt-get -y install gcc-arm-none-eabi
 
     - name: Build example
-      run: cd examples/edhoc-rs-no_std && cargo build --target="thumbv7em-none-eabihf" --no-default-features --features="${{ matrix.edhoc_lib }}-${{ matrix.crypto }}, rtt" --release
+      # FIXME: still failing
+      run: cd examples/edhoc-rs-no_std && cargo build --target="thumbv7em-none-eabihf" --no-default-features --features="${{ matrix.edhoc_lib }}-${{ matrix.crypto }}, ${{ matrix.ead }}, rtt" --release
 
 
   build-coap-example:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ members = [
   "lib",
   "hacspec",
   "ead",
+  "ead/edhoc-ead-none",
+  "ead/edhoc-ead-zeroconf",
   "crypto",
   "crypto/edhoc-crypto-cc2538",
   "crypto/edhoc-crypto-hacspec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
   "lib",
   "hacspec",
+  "ead",
   "crypto",
   "crypto/edhoc-crypto-cc2538",
   "crypto/edhoc-crypto-hacspec",
@@ -18,6 +19,7 @@ members = [
 default-members = [
   "lib",
   "hacspec",
+  "ead",
   "crypto",
   "crypto/edhoc-crypto-hacspec",
   "examples/coap",

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -74,6 +74,24 @@ mod common {
         }
     }
 
+    #[derive(Debug)]
+    pub struct EADItem {
+        pub label: u8,
+        pub is_critical: bool,
+        // TODO[ead]: have adjustable (smaller) length for this buffer
+        pub value: Option<EdhocMessageBuffer>,
+    }
+
+    impl EADItem {
+       pub fn new() -> Self {
+            EADItem {
+                label: 0,
+                is_critical: false,
+                value: None,
+            }
+        }
+    }
+
     pub const MAX_MESSAGE_SIZE_LEN: usize = 64;
     pub const MAX_EAD_SIZE_LEN: usize = 64;
     pub type EADMessageBuffer = EdhocMessageBuffer; // TODO: make it of size MAX_EAD_SIZE_LEN
@@ -113,14 +131,6 @@ mod common {
 #[cfg(feature = "rust")]
 mod rust {
     use super::common::*;
-
-    #[derive(Debug)]
-    pub struct EADItem {
-        pub label: u8,
-        pub is_critical: bool,
-        // TODO[ead]: have adjustable (smaller) length for this buffer
-        pub value: Option<EdhocMessageBuffer>,
-    }
 
     pub type U8 = u8;
     pub type BytesEad2 = [u8; 0];
@@ -225,11 +235,31 @@ mod hacspec {
     }
 
     #[derive(Debug)]
-    pub struct EADItem {
-        pub label: u8,
+    pub struct EADItemHacspec {
+        pub label: U8,
         pub is_critical: bool,
         // TODO[ead]: have adjustable (smaller) length for this buffer
         pub value: Option<EdhocMessageBufferHacspec>,
+    }
+
+    impl EADItemHacspec {
+        pub fn new() -> Self {
+            EADItemHacspec {
+                label: U8(0),
+                is_critical: false,
+                value: None,
+            }
+        }
+        pub fn from_public_item(item: &EADItem) -> Self {
+            EADItemHacspec {
+                label: U8(item.label),
+                is_critical: item.is_critical,
+                value: match &item.value {
+                    Some(value) => Some(EdhocMessageBufferHacspec::from_public_buffer(value)),
+                    None => None,
+                },
+            }
+        }
     }
 
     array!(BytesIdCred, ID_CRED_LEN, U8);

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -74,10 +74,14 @@ mod common {
         }
     }
 
+    pub const MAX_MESSAGE_SIZE_LEN: usize = 64;
+    pub const MAX_EAD_SIZE_LEN: usize = 64;
+    pub type EADMessageBuffer = EdhocMessageBuffer; // TODO: make it of size MAX_EAD_SIZE_LEN
+    pub const EAD_ZEROCONF_LABEL: u8 = 0x1; // NOTE: in lake-authz-draft-02 it is still TBD1
+
     pub const ID_CRED_LEN: usize = 4;
     pub const SUITES_LEN: usize = 9;
     pub const SUPPORTED_SUITES_LEN: usize = 1;
-    pub const MAX_MESSAGE_SIZE_LEN: usize = 64;
     pub const EDHOC_METHOD: u8 = 3u8; // stat-stat is the only supported method
     pub const P256_ELEM_LEN: usize = 32;
     pub const SHA256_DIGEST_LEN: usize = 32;
@@ -93,6 +97,8 @@ mod common {
     pub const MAX_BUFFER_LEN: usize = 220;
     pub const CBOR_BYTE_STRING: u8 = 0x58u8;
     pub const CBOR_UINT_1BYTE: u8 = 0x18u8;
+    pub const CBOR_NEG_INT_RANGE_START: u8 = 0x20u8;
+    pub const CBOR_NEG_INT_RANGE_END: u8 = 0x37u8;
     pub const CBOR_MAJOR_TEXT_STRING: u8 = 0x60u8;
     pub const CBOR_MAJOR_BYTE_STRING: u8 = 0x40u8;
     pub const CBOR_MAJOR_ARRAY: u8 = 0x80u8;

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -84,7 +84,7 @@ mod common {
     }
 
     impl EADItem {
-       pub fn new() -> Self {
+        pub fn new() -> Self {
             EADItem {
                 label: 0,
                 is_critical: false,

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -30,7 +30,8 @@ mod common {
         UnsupportedCipherSuite = 4,
         ParsingError = 5,
         WrongState = 6,
-        UnknownError = 7,
+        EADError = 7,
+        UnknownError = 8,
     }
 
     #[derive(PartialEq, Debug)]
@@ -256,6 +257,16 @@ mod hacspec {
                 is_critical: item.is_critical,
                 value: match &item.value {
                     Some(value) => Some(EdhocMessageBufferHacspec::from_public_buffer(value)),
+                    None => None,
+                },
+            }
+        }
+        pub fn to_public_item(&self) -> EADItem {
+            EADItem {
+                label: self.label.declassify(),
+                is_critical: self.is_critical,
+                value: match &self.value {
+                    Some(value) => Some(value.to_public_buffer()),
                     None => None,
                 },
             }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,7 +22,7 @@ edhoc-crypto-psa = { path = "./edhoc-crypto-psa", default-features = false, opti
 edhoc-crypto-cryptocell310 = { path = "./edhoc-crypto-cryptocell310-sys", optional = true }
 
 [features]
-default = [ "hacspec" ]
+default = [  ]
 hacspec = [ "edhoc-crypto-hacspec" ]
 cc2538 = [ "edhoc-crypto-cc2538" ]
 psa = [ "edhoc-crypto-psa/hacspec" ]

--- a/ead/Cargo.toml
+++ b/ead/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "edhoc-ead"
+version = "0.1.0"
+edition = "2021"
+authors = ["Geovane Fedrecheski <geonnave@gmail.com>"]
+license = "BSD"
+description = "EDHOC EAD library dispatch crate"
+
+[dependencies]
+edhoc-consts = { path = "../consts", default-features = false }
+
+edhoc-ead-none = { path = "./edhoc-ead-none", optional = true }
+edhoc-ead-zeroconf = { path = "./edhoc-ead-zeroconf", optional = true }
+
+[features]
+default = [ "ead-none" ]
+ead-none = [ "edhoc-ead-none" ]
+ead-zeroconf = [ "edhoc-ead-zeroconf" ]

--- a/ead/edhoc-ead-none/Cargo.toml
+++ b/ead/edhoc-ead-none/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "edhoc-ead-none"
+version = "0.1.0"
+edition = "2021"
+authors = ["Geovane Fedrecheski <geonnave@gmail.com>"]
+license = "BSD"
+description = "EDHOC EAD none (just a placeholder)"
+
+[dependencies]
+edhoc-consts = { path = "../../consts" }

--- a/ead/edhoc-ead-none/src/lib.rs
+++ b/ead/edhoc-ead-none/src/lib.rs
@@ -1,0 +1,27 @@
+use edhoc_consts::*;
+
+// initiator side
+pub fn i_prepare_ead_1() -> EADMessageBuffer {
+    EADMessageBuffer::new()
+}
+
+pub fn i_process_ead_2(ead_2: EADMessageBuffer) -> Result<(), ()> {
+    Ok(())
+}
+
+pub fn i_prepare_ead_3() -> EADMessageBuffer {
+    EADMessageBuffer::new()
+}
+
+// responder side
+pub fn r_process_ead_1(ead_1: EADMessageBuffer) -> Result<(), ()> {
+    Ok(())
+}
+
+pub fn r_prepare_ead_2() -> EADMessageBuffer {
+    EADMessageBuffer::new()
+}
+
+pub fn r_process_ead_3(ead_3: EADMessageBuffer) -> Result<(), ()> {
+    Ok(())
+}

--- a/ead/edhoc-ead-none/src/lib.rs
+++ b/ead/edhoc-ead-none/src/lib.rs
@@ -1,27 +1,27 @@
 use edhoc_consts::*;
 
 // initiator side
-pub fn i_prepare_ead_1() -> EADMessageBuffer {
-    EADMessageBuffer::new()
+pub fn i_prepare_ead_1() -> EADItem {
+    EADItem::new()
 }
 
-pub fn i_process_ead_2(ead_2: EADMessageBuffer) -> Result<(), ()> {
+pub fn i_process_ead_2(ead_2: EADItem) -> Result<(), ()> {
     Ok(())
 }
 
-pub fn i_prepare_ead_3() -> EADMessageBuffer {
-    EADMessageBuffer::new()
+pub fn i_prepare_ead_3() -> EADItem {
+    EADItem::new()
 }
 
 // responder side
-pub fn r_process_ead_1(ead_1: EADMessageBuffer) -> Result<(), ()> {
+pub fn r_process_ead_1(ead_1: EADItem) -> Result<(), ()> {
     Ok(())
 }
 
-pub fn r_prepare_ead_2() -> EADMessageBuffer {
-    EADMessageBuffer::new()
+pub fn r_prepare_ead_2() -> EADItem {
+    EADItem::new()
 }
 
-pub fn r_process_ead_3(ead_3: EADMessageBuffer) -> Result<(), ()> {
+pub fn r_process_ead_3(ead_3: EADItem) -> Result<(), ()> {
     Ok(())
 }

--- a/ead/edhoc-ead-none/src/lib.rs
+++ b/ead/edhoc-ead-none/src/lib.rs
@@ -1,16 +1,16 @@
 use edhoc_consts::*;
 
 // initiator side
-pub fn i_prepare_ead_1() -> EADItem {
-    EADItem::new()
+pub fn i_prepare_ead_1() -> Option<EADItem> {
+    Some(EADItem::new())
 }
 
 pub fn i_process_ead_2(ead_2: EADItem) -> Result<(), ()> {
     Ok(())
 }
 
-pub fn i_prepare_ead_3() -> EADItem {
-    EADItem::new()
+pub fn i_prepare_ead_3() -> Option<EADItem> {
+    Some(EADItem::new())
 }
 
 // responder side
@@ -18,8 +18,8 @@ pub fn r_process_ead_1(ead_1: EADItem) -> Result<(), ()> {
     Ok(())
 }
 
-pub fn r_prepare_ead_2() -> EADItem {
-    EADItem::new()
+pub fn r_prepare_ead_2() -> Option<EADItem> {
+    Some(EADItem::new())
 }
 
 pub fn r_process_ead_3(ead_3: EADItem) -> Result<(), ()> {

--- a/ead/edhoc-ead-none/src/lib.rs
+++ b/ead/edhoc-ead-none/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 use edhoc_consts::*;
 
 // initiator side

--- a/ead/edhoc-ead-zeroconf/Cargo.toml
+++ b/ead/edhoc-ead-zeroconf/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "edhoc-ead-zeroconf"
+version = "0.1.0"
+edition = "2021"
+authors = ["Geovane Fedrecheski <geonnave@gmail.com>"]
+license = "BSD"
+description = "EDHOC EAD zeroconf (draf-lake-authz)"
+
+[dependencies]
+edhoc-consts = { path = "../../consts" }

--- a/ead/edhoc-ead-zeroconf/src/lib.rs
+++ b/ead/edhoc-ead-zeroconf/src/lib.rs
@@ -1,0 +1,66 @@
+#![no_std]
+
+use edhoc_consts::*;
+
+// initiator side
+pub fn i_prepare_ead_1() -> EADMessageBuffer {
+    let mut ead_1 = EADMessageBuffer::new();
+
+    // add the label to the buffer, tagged as critical,
+    // which means encoding it as a negative value, i.e., -label
+    ead_1.content[0] = CBOR_NEG_INT_RANGE_START + EAD_ZEROCONF_LABEL;
+    ead_1.len = 1;
+
+    // TODO: build Voucher_Info (LOC_W, ENC_ID), and append it to the buffer
+
+    // state.protocol_state = EADInitiatorProtocolState::WaitEAD2;
+
+    ead_1
+}
+
+pub fn i_process_ead_2(ead_2: EADMessageBuffer) -> Result<(), ()> {
+    // TODO: verify the label
+    // TODO: verify the voucher
+
+    // state.protocol_state = EADInitiatorProtocolState::Completed;
+
+    Ok(())
+}
+
+pub fn i_prepare_ead_3() -> EADMessageBuffer {
+    EADMessageBuffer::new()
+}
+
+// responder side
+pub fn r_process_ead_1(ead_1: EADMessageBuffer) -> Result<(), ()> {
+    // TODO: parse and verify the label
+    // TODO: trigger the voucher request to W
+
+    // state.protocol_state = EADResponderProtocolState::ProcessedEAD1;
+
+    Ok(())
+}
+
+pub fn r_prepare_ead_2() -> EADMessageBuffer {
+    let mut ead_2 = EADMessageBuffer::new();
+
+    // add the label to the buffer (non-critical)
+    ead_2.content[0] = EAD_ZEROCONF_LABEL;
+    ead_2.len = 1;
+
+    // TODO: append Voucher (H(message_1), CRED_V) to the buffer
+
+    // // NOTE: see the note in lib.rs::test_ead
+    // // state.protocol_state = EADResponderProtocolState::WaitMessage3;
+    // state.protocol_state = EADResponderProtocolState::Completed;
+
+    ead_2
+}
+
+pub fn r_process_ead_3(ead_3: EADMessageBuffer) -> Result<(), ()> {
+    // TODO: maybe retrive CRED_U from a Credential Database
+
+    // state.protocol_state = EADResponderProtocolState::Completed;
+
+    Ok(())
+}

--- a/ead/edhoc-ead-zeroconf/src/lib.rs
+++ b/ead/edhoc-ead-zeroconf/src/lib.rs
@@ -3,13 +3,12 @@
 use edhoc_consts::*;
 
 // initiator side
-pub fn i_prepare_ead_1() -> EADMessageBuffer {
-    let mut ead_1 = EADMessageBuffer::new();
+pub fn i_prepare_ead_1() -> EADItem {
+    let mut ead_1 = EADItem::new();
 
-    // add the label to the buffer, tagged as critical,
-    // which means encoding it as a negative value, i.e., -label
-    ead_1.content[0] = CBOR_NEG_INT_1BYTE_START + EAD_ZEROCONF_LABEL;
-    ead_1.len = 1;
+    // this ead item is critical
+    ead_1.label = EAD_ZEROCONF_LABEL;
+    ead_1.is_critical = true;
 
     // TODO: build Voucher_Info (LOC_W, ENC_ID), and append it to the buffer
 
@@ -18,7 +17,7 @@ pub fn i_prepare_ead_1() -> EADMessageBuffer {
     ead_1
 }
 
-pub fn i_process_ead_2(ead_2: EADMessageBuffer) -> Result<(), ()> {
+pub fn i_process_ead_2(ead_2: EADItem) -> Result<(), ()> {
     // TODO: verify the label
     // TODO: verify the voucher
 
@@ -27,12 +26,12 @@ pub fn i_process_ead_2(ead_2: EADMessageBuffer) -> Result<(), ()> {
     Ok(())
 }
 
-pub fn i_prepare_ead_3() -> EADMessageBuffer {
-    EADMessageBuffer::new()
+pub fn i_prepare_ead_3() -> EADItem {
+    EADItem::new()
 }
 
 // responder side
-pub fn r_process_ead_1(ead_1: EADMessageBuffer) -> Result<(), ()> {
+pub fn r_process_ead_1(ead_1: EADItem) -> Result<(), ()> {
     // TODO: parse and verify the label
     // TODO: trigger the voucher request to W
 
@@ -41,12 +40,12 @@ pub fn r_process_ead_1(ead_1: EADMessageBuffer) -> Result<(), ()> {
     Ok(())
 }
 
-pub fn r_prepare_ead_2() -> EADMessageBuffer {
-    let mut ead_2 = EADMessageBuffer::new();
+pub fn r_prepare_ead_2() -> EADItem {
+    let mut ead_2 = EADItem::new();
 
     // add the label to the buffer (non-critical)
-    ead_2.content[0] = EAD_ZEROCONF_LABEL;
-    ead_2.len = 1;
+    ead_2.label = EAD_ZEROCONF_LABEL;
+    ead_2.is_critical = true;
 
     // TODO: append Voucher (H(message_1), CRED_V) to the buffer
 
@@ -57,7 +56,7 @@ pub fn r_prepare_ead_2() -> EADMessageBuffer {
     ead_2
 }
 
-pub fn r_process_ead_3(ead_3: EADMessageBuffer) -> Result<(), ()> {
+pub fn r_process_ead_3(ead_3: EADItem) -> Result<(), ()> {
     // TODO: maybe retrive CRED_U from a Credential Database
 
     // state.protocol_state = EADResponderProtocolState::Completed;

--- a/ead/edhoc-ead-zeroconf/src/lib.rs
+++ b/ead/edhoc-ead-zeroconf/src/lib.rs
@@ -68,7 +68,6 @@ pub fn i_prepare_ead_3() -> Option<EADItem> {
     Some(EADItem::new())
 }
 
-
 // responder side
 #[derive(Default, PartialEq, Copy, Clone, Debug)]
 pub enum EADResponderProtocolState {

--- a/ead/src/lib.rs
+++ b/ead/src/lib.rs
@@ -1,0 +1,7 @@
+#![no_std]
+
+#[cfg(feature = "ead-none")]
+pub use edhoc_ead_none::*;
+
+#[cfg(feature = "ead-zeroconf")]
+pub use edhoc_ead_zeroconf::*;

--- a/examples/edhoc-rs-no_std/Cargo.toml
+++ b/examples/edhoc-rs-no_std/Cargo.toml
@@ -20,10 +20,12 @@ panic-semihosting = { version = "0.6.0", features = ["exit"] }
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 
 [features]
-default = [ "hacspec-psa" ]
+default = [ ]
 hacspec-cc2538 = [ "edhoc-rs/hacspec-cc2538" ]
 hacspec-psa = [ "edhoc-rs/hacspec-psa-baremetal" ]
 rust-psa = [ "edhoc-rs/rust-psa-baremetal" ]
 rtt = [ ]
 hacspec-cryptocell310 = [ "edhoc-rs/hacspec-cryptocell310" ]
 rust-cryptocell310 = [ "edhoc-rs/rust-cryptocell310" ]
+ead-none = [ "edhoc-rs/ead-none" ]
+ead-zeroconf = [ "edhoc-rs/ead-zeroconf" ]

--- a/hacspec/Cargo.toml
+++ b/hacspec/Cargo.toml
@@ -9,5 +9,5 @@ description = "EDHOC implementation"
 [dependencies]
 hacspec-lib = { version = "0.1.0-beta.1", default-features = false, features = [ "alloc" ] }
 edhoc-crypto = { path = "../crypto", default-features = false }
+edhoc-ead = { path = "../ead", default-features = false }
 edhoc-consts = { path = "../consts" }
-

--- a/hacspec/Cargo.toml
+++ b/hacspec/Cargo.toml
@@ -11,3 +11,8 @@ hacspec-lib = { version = "0.1.0-beta.1", default-features = false, features = [
 edhoc-crypto = { path = "../crypto", default-features = false }
 edhoc-ead = { path = "../ead", default-features = false }
 edhoc-consts = { path = "../consts" }
+
+[features]
+default = [ "edhoc-ead/edhoc-ead-none" ]
+ead-none = [ "edhoc-ead/edhoc-ead-none" ]
+ead-zeroconf = [ "edhoc-ead/edhoc-ead-zeroconf" ]

--- a/hacspec/src/lib.rs
+++ b/hacspec/src/lib.rs
@@ -740,7 +740,8 @@ fn parse_ead(
     offset: usize,
 ) -> Result<Option<EADItemHacspec>, EDHOCError> {
     let mut error: EDHOCError = EDHOCError::UnknownError;
-    let mut ead_1 = None::<EADItemHacspec>;
+    let mut ead_item = None::<EADItemHacspec>;
+    let mut ead_value = None::<EdhocMessageBufferHacspec>;
 
     // assume label is either a single byte integer (negative or positive)
     let label = message.content[offset];
@@ -754,15 +755,18 @@ fn parse_ead(
 
     if res_label.is_ok() {
         let (label, is_critical) = res_label.unwrap();
-        let value = EdhocMessageBufferHacspec::from_slice(
-            &message.content,
-            offset + 1,
-            message.len - (offset + 1),
-        );
-        ead_1 = Some(EADItemHacspec {
+        if message.len > (offset + 1) { // EAD value is present
+            let buffer = EdhocMessageBufferHacspec::from_slice(
+                &message.content,
+                offset + 1,
+                message.len - (offset + 1),
+            );
+            ead_value = Some(buffer);
+        }
+        ead_item = Some(EADItemHacspec {
             label: U8(label),
             is_critical,
-            value: Some(value),
+            value: ead_value,
         });
         error = EDHOCError::Success;
     } else {
@@ -770,7 +774,7 @@ fn parse_ead(
     }
 
     match error {
-        EDHOCError::Success => Ok(ead_1),
+        EDHOCError::Success => Ok(ead_item),
         _ => Err(error),
     }
 }
@@ -1457,6 +1461,8 @@ mod tests {
     const EAD_DUMMY_LABEL_TV: u8 = 0x01;
     const EAD_DUMMY_VALUE_TV: &str = "cccccc";
     const EAD_DUMMY_CRITICAL_TV: &str = "20cccccc";
+    const MESSAGE_1_WITH_DUMMY_EAD_NO_VALUE_TV: &str =
+        "0382060258208af6f430ebe18d34184017a9a11bf511c8dff8f834730b96c1b7c8dbca2fc3b63701";
     const MESSAGE_1_WITH_DUMMY_EAD_TV: &str =
         "0382060258208af6f430ebe18d34184017a9a11bf511c8dff8f834730b96c1b7c8dbca2fc3b63701cccccc";
     const MESSAGE_1_WITH_DUMMY_CRITICAL_EAD_TV: &str =
@@ -1927,6 +1933,14 @@ mod tests {
         assert!(ead_item.is_critical);
         assert_eq!(ead_item.label.declassify(), EAD_DUMMY_LABEL_TV);
         assert_bytes_eq!(ead_item.value.unwrap().content, ead_value_tv.content);
+
+        let message_ead_tv = BufferMessage1::from_hex(MESSAGE_1_WITH_DUMMY_EAD_NO_VALUE_TV);
+
+        let res = parse_ead(&message_ead_tv, message_tv_offset).unwrap();
+        let ead_item = res.unwrap();
+        assert!(!ead_item.is_critical);
+        assert_eq!(ead_item.label.declassify(), EAD_DUMMY_LABEL_TV);
+        assert!(ead_item.value.is_none());
     }
 
     #[test]

--- a/hacspec/src/lib.rs
+++ b/hacspec/src/lib.rs
@@ -258,7 +258,8 @@ pub fn r_process_message_3(
                 };
                 if ead_success {
                     // compare the kid received with the kid expected in id_cred_i
-                    if kid.declassify() == id_cred_i_expected[id_cred_i_expected.len() - 1].declassify()
+                    if kid.declassify()
+                        == id_cred_i_expected[id_cred_i_expected.len() - 1].declassify()
                     {
                         // compute salt_4e3m
                         let salt_4e3m = compute_salt_4e3m(&prk_3e2m, &th_3);
@@ -277,7 +278,8 @@ pub fn r_process_message_3(
                         // verify mac_3
                         if mac_3.declassify_eq(&expected_mac_3) {
                             error = EDHOCError::Success;
-                            let th_4 = compute_th_4(&th_3, &plaintext_3, cred_i_expected, cred_i_len);
+                            let th_4 =
+                                compute_th_4(&th_3, &plaintext_3, cred_i_expected, cred_i_len);
 
                             // compute prk_out
                             // PRK_out = EDHOC-KDF( PRK_4e3m, 7, TH_4, hash_length )
@@ -299,8 +301,12 @@ pub fn r_process_message_3(
                                 0,
                                 SHA256_DIGEST_LEN,
                             );
-                            prk_exporter =
-                                prk_exporter.update_slice(0, &prk_exporter_buf, 0, SHA256_DIGEST_LEN);
+                            prk_exporter = prk_exporter.update_slice(
+                                0,
+                                &prk_exporter_buf,
+                                0,
+                                SHA256_DIGEST_LEN,
+                            );
 
                             error = EDHOCError::Success;
                             current_state = EDHOCState::Completed;
@@ -499,7 +505,8 @@ pub fn i_process_message_2(
 
                 // Check MAC before checking KID
                 if mac_2.declassify_eq(&expected_mac_2) {
-                    if kid.declassify() == id_cred_r_expected[id_cred_r_expected.len() - 1].declassify()
+                    if kid.declassify()
+                        == id_cred_r_expected[id_cred_r_expected.len() - 1].declassify()
                     {
                         // step is actually from processing of message_3
                         // but we do it here to avoid storing plaintext_2 in State
@@ -755,7 +762,8 @@ fn parse_ead(
 
     if res_label.is_ok() {
         let (label, is_critical) = res_label.unwrap();
-        if message.len > (offset + 1) { // EAD value is present
+        if message.len > (offset + 1) {
+            // EAD value is present
             let buffer = EdhocMessageBufferHacspec::from_slice(
                 &message.content,
                 offset + 1,

--- a/hacspec/src/lib.rs
+++ b/hacspec/src/lib.rs
@@ -2,6 +2,7 @@
 
 use edhoc_consts::*;
 use edhoc_crypto::*;
+use edhoc_ead::*;
 use hacspec_lib::*;
 
 pub fn edhoc_exporter(
@@ -354,6 +355,8 @@ pub fn i_prepare_message_1(
 
         // Choose a connection identifier C_I and store it for the length of the protocol.
         c_i = C_I;
+
+        let ead_1 = i_prepare_ead_1();
 
         // Encode message_1 as a sequence of CBOR encoded data items as specified in Section 5.2.1
         message_1 = encode_message_1(

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,7 +17,7 @@ edhoc-consts = { path = "../consts", default-features = false }
 edhoc-ead = { path = "../ead", default-features = false }
 
 [features]
-default = [ "edhoc-ead/edhoc-ead-none" ]
+default = [ "edhoc-ead/ead-none" ]
 hacspec-hacspec = ["hacspec-lib/std", "edhoc-hacspec", "edhoc-crypto/hacspec", "edhoc-consts/hacspec" ]
 hacspec-cc2538 = ["hacspec-lib/alloc", "edhoc-hacspec", "edhoc-crypto/cc2538", "edhoc-consts/hacspec" ] # FIXME: stubs
 hacspec-psa = ["hacspec-lib/alloc", "edhoc-hacspec", "edhoc-crypto/psa", "edhoc-consts/hacspec" ]
@@ -26,5 +26,5 @@ hacspec-cryptocell310 = ["hacspec-lib/alloc", "edhoc-hacspec", "edhoc-crypto/cry
 rust-psa = [ "edhoc-consts/rust", "edhoc-crypto/psa-rust" ]
 rust-psa-baremetal = [ "edhoc-crypto/psa-rust-baremetal", "edhoc-consts/rust" ]
 rust-cryptocell310 = [ "edhoc-consts/rust", "edhoc-crypto/cryptocell310-rust" ]
-ead-none = [ "edhoc-ead/edhoc-ead-none" ]
-ead-zeroconf = [ "edhoc-ead/edhoc-ead-zeroconf" ]
+ead-none = [ "edhoc-ead/ead-none" ]
+ead-zeroconf = [ "edhoc-ead/ead-zeroconf" ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,7 +17,7 @@ edhoc-consts = { path = "../consts", default-features = false }
 edhoc-ead = { path = "../ead", default-features = false }
 
 [features]
-default = [ ]
+default = [ "edhoc-ead/edhoc-ead-none" ]
 hacspec-hacspec = ["hacspec-lib/std", "edhoc-hacspec", "edhoc-crypto/hacspec", "edhoc-consts/hacspec" ]
 hacspec-cc2538 = ["hacspec-lib/alloc", "edhoc-hacspec", "edhoc-crypto/cc2538", "edhoc-consts/hacspec" ] # FIXME: stubs
 hacspec-psa = ["hacspec-lib/alloc", "edhoc-hacspec", "edhoc-crypto/psa", "edhoc-consts/hacspec" ]
@@ -26,5 +26,5 @@ hacspec-cryptocell310 = ["hacspec-lib/alloc", "edhoc-hacspec", "edhoc-crypto/cry
 rust-psa = [ "edhoc-consts/rust", "edhoc-crypto/psa-rust" ]
 rust-psa-baremetal = [ "edhoc-crypto/psa-rust-baremetal", "edhoc-consts/rust" ]
 rust-cryptocell310 = [ "edhoc-consts/rust", "edhoc-crypto/cryptocell310-rust" ]
-ead-none = [ ]
+ead-none = [ "edhoc-ead/edhoc-ead-none" ]
 ead-zeroconf = [ "edhoc-ead/edhoc-ead-zeroconf" ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -25,3 +25,5 @@ hacspec-cryptocell310 = ["hacspec-lib/alloc", "edhoc-hacspec", "edhoc-crypto/cry
 rust-psa = [ "edhoc-consts/rust", "edhoc-crypto/psa-rust" ]
 rust-psa-baremetal = [ "edhoc-crypto/psa-rust-baremetal", "edhoc-consts/rust" ]
 rust-cryptocell310 = [ "edhoc-consts/rust", "edhoc-crypto/cryptocell310-rust" ]
+ead-none = [ ]
+ead-zeroconf = [ ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,6 +14,7 @@ edhoc-hacspec = { path = "../hacspec", optional = true }
 hacspec-lib = { version = "0.1.0-beta.1", default-features = false, optional = true }
 edhoc-crypto = { path = "../crypto", default-features = false }
 edhoc-consts = { path = "../consts", default-features = false }
+edhoc-ead = { path = "../ead", default-features = false }
 
 [features]
 default = [ ]
@@ -26,4 +27,4 @@ rust-psa = [ "edhoc-consts/rust", "edhoc-crypto/psa-rust" ]
 rust-psa-baremetal = [ "edhoc-crypto/psa-rust-baremetal", "edhoc-consts/rust" ]
 rust-cryptocell310 = [ "edhoc-consts/rust", "edhoc-crypto/cryptocell310-rust" ]
 ead-none = [ ]
-ead-zeroconf = [ ]
+ead-zeroconf = [ "edhoc-ead/edhoc-ead-zeroconf" ]

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -706,7 +706,8 @@ fn parse_ead(message: &EdhocMessageBuffer, offset: usize) -> Result<Option<EADIt
 
     if res_label.is_ok() {
         let (label, is_critical) = res_label.unwrap();
-        if message.len > (offset + 1) { // EAD value is present
+        if message.len > (offset + 1) {
+            // EAD value is present
             let mut buffer = EdhocMessageBuffer::new();
             buffer.content[..message.len - (offset + 1)]
                 .copy_from_slice(&message.content[offset + 1..message.len]);
@@ -1241,9 +1242,7 @@ fn decode_plaintext_2(
         // NOTE: since the current implementation only supports one EAD handler,
         // we assume only one EAD item
         let ead_res = parse_ead(
-            &plaintext_2[..plaintext_2_len]
-                .try_into()
-                .expect("too long"),
+            &plaintext_2[..plaintext_2_len].try_into().expect("too long"),
             2 + MAC_LENGTH_2,
         );
         if ead_res.is_ok() {

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -2,6 +2,7 @@
 
 use edhoc_consts::*;
 use edhoc_crypto::*;
+use edhoc_ead::*;
 
 pub fn edhoc_exporter(
     state: State,
@@ -59,35 +60,42 @@ pub fn r_process_message_1(
         let res = parse_message_1(message_1);
 
         if res.is_ok() {
-            let (method, suites_i, suites_i_len, g_x, c_i, _ead_1) = res.unwrap();
+            let (method, suites_i, suites_i_len, g_x, c_i, ead_1) = res.unwrap();
             // verify that the method is supported
             if method == EDHOC_METHOD {
                 // Step 2: verify that the selected cipher suite is supported
                 if suites_i[suites_i_len - 1] == EDHOC_SUPPORTED_SUITES[0] {
                     // Step 3: If EAD is present make it available to the application
-                    // TODO we do not support EAD for now
+                    let ead_success = if let Some(ead_1) = ead_1 {
+                        r_process_ead_1(ead_1).is_ok()
+                    } else {
+                        true
+                    };
+                    if ead_success {
+                        // hash message_1 and save the hash to the state to avoid saving the whole message
+                        let mut message_1_buf: BytesMaxBuffer = [0x00; MAX_BUFFER_LEN];
+                        message_1_buf[..message_1.len]
+                            .copy_from_slice(&message_1.content[..message_1.len]);
+                        h_message_1 = sha256_digest(&message_1_buf, message_1.len);
 
-                    // hash message_1 and save the hash to the state to avoid saving the whole message
-                    let mut message_1_buf: BytesMaxBuffer = [0x00; MAX_BUFFER_LEN];
-                    message_1_buf[..message_1.len]
-                        .copy_from_slice(&message_1.content[..message_1.len]);
-                    h_message_1 = sha256_digest(&message_1_buf, message_1.len);
+                        error = EDHOCError::Success;
+                        current_state = EDHOCState::ProcessedMessage1;
 
-                    error = EDHOCError::Success;
-                    current_state = EDHOCState::ProcessedMessage1;
-
-                    state = construct_state(
-                        current_state,
-                        _y,
-                        c_i,
-                        g_x,
-                        _prk_3e2m,
-                        _prk_4e3m,
-                        _prk_out,
-                        _prk_exporter,
-                        h_message_1,
-                        _th_3,
-                    );
+                        state = construct_state(
+                            current_state,
+                            _y,
+                            c_i,
+                            g_x,
+                            _prk_3e2m,
+                            _prk_4e3m,
+                            _prk_out,
+                            _prk_exporter,
+                            h_message_1,
+                            _th_3,
+                        );
+                    } else {
+                        error = EDHOCError::EADError;
+                    }
                 } else {
                     error = EDHOCError::UnsupportedCipherSuite;
                 }
@@ -148,8 +156,10 @@ pub fn r_prepare_message_2(
         // compute MAC_2
         let mac_2 = compute_mac_2(&prk_3e2m, id_cred_r, cred_r, cred_r_len, &th_2);
 
+        let ead_2 = r_prepare_ead_2();
+
         // compute ciphertext_2
-        let plaintext_2 = encode_plaintext_2(id_cred_r, &mac_2, &None::<EADItem>);
+        let plaintext_2 = encode_plaintext_2(id_cred_r, &mac_2, &ead_2);
 
         // step is actually from processing of message_3
         // but we do it here to avoid storing plaintext_2 in State
@@ -222,70 +232,81 @@ pub fn r_process_message_3(
             let decoded_p3_res = decode_plaintext_3(&plaintext_3);
 
             if decoded_p3_res.is_ok() {
-                let (kid, mac_3, _ead_3) = decoded_p3_res.unwrap();
+                let (kid, mac_3, ead_3) = decoded_p3_res.unwrap();
 
-                // compare the kid received with the kid expected in id_cred_i
-                if kid == id_cred_i_expected[id_cred_i_expected.len() - 1] {
-                    // compute salt_4e3m
-                    let salt_4e3m = compute_salt_4e3m(&prk_3e2m, &th_3);
-                    // TODO compute prk_4e3m
-                    prk_4e3m = compute_prk_4e3m(&salt_4e3m, &y, g_i);
+                // Step 3: If EAD is present make it available to the application
+                let ead_success = if let Some(ead_3) = ead_3 {
+                    r_process_ead_3(ead_3).is_ok()
+                } else {
+                    true
+                };
+                if ead_success {
+                    // compare the kid received with the kid expected in id_cred_i
+                    if kid == id_cred_i_expected[id_cred_i_expected.len() - 1] {
+                        // compute salt_4e3m
+                        let salt_4e3m = compute_salt_4e3m(&prk_3e2m, &th_3);
+                        // TODO compute prk_4e3m
+                        prk_4e3m = compute_prk_4e3m(&salt_4e3m, &y, g_i);
 
-                    // compute mac_3
-                    let expected_mac_3 = compute_mac_3(
-                        &prk_4e3m,
-                        &th_3,
-                        id_cred_i_expected,
-                        cred_i_expected,
-                        cred_i_len,
-                    );
-
-                    // verify mac_3
-                    if mac_3 == expected_mac_3 {
-                        error = EDHOCError::Success;
-                        let th_4 = compute_th_4(&th_3, &plaintext_3, cred_i_expected, cred_i_len);
-
-                        let mut th_4_buf: BytesMaxContextBuffer = [0x00; MAX_KDF_CONTEXT_LEN];
-                        th_4_buf[..th_4.len()].copy_from_slice(&th_4[..]);
-                        // compute prk_out
-                        // PRK_out = EDHOC-KDF( PRK_4e3m, 7, TH_4, hash_length )
-                        let prk_out_buf =
-                            edhoc_kdf(&prk_4e3m, 7u8, &th_4_buf, th_4.len(), SHA256_DIGEST_LEN);
-                        prk_out[..SHA256_DIGEST_LEN]
-                            .copy_from_slice(&prk_out_buf[..SHA256_DIGEST_LEN]);
-
-                        // compute prk_exporter from prk_out
-                        // PRK_exporter  = EDHOC-KDF( PRK_out, 10, h'', hash_length )
-                        let prk_exporter_buf = edhoc_kdf(
-                            &prk_out,
-                            10u8,
-                            &[0x00u8; MAX_KDF_CONTEXT_LEN],
-                            0,
-                            SHA256_DIGEST_LEN,
+                        // compute mac_3
+                        let expected_mac_3 = compute_mac_3(
+                            &prk_4e3m,
+                            &th_3,
+                            id_cred_i_expected,
+                            cred_i_expected,
+                            cred_i_len,
                         );
-                        prk_exporter[..SHA256_DIGEST_LEN]
-                            .copy_from_slice(&prk_exporter_buf[..SHA256_DIGEST_LEN]);
 
-                        error = EDHOCError::Success;
-                        current_state = EDHOCState::Completed;
+                        // verify mac_3
+                        if mac_3 == expected_mac_3 {
+                            error = EDHOCError::Success;
+                            let th_4 =
+                                compute_th_4(&th_3, &plaintext_3, cred_i_expected, cred_i_len);
 
-                        state = construct_state(
-                            current_state,
-                            y,
-                            _c_i,
-                            _g_x,
-                            prk_3e2m,
-                            prk_4e3m,
-                            prk_out,
-                            prk_exporter,
-                            _h_message_1,
-                            th_3,
-                        );
+                            let mut th_4_buf: BytesMaxContextBuffer = [0x00; MAX_KDF_CONTEXT_LEN];
+                            th_4_buf[..th_4.len()].copy_from_slice(&th_4[..]);
+                            // compute prk_out
+                            // PRK_out = EDHOC-KDF( PRK_4e3m, 7, TH_4, hash_length )
+                            let prk_out_buf =
+                                edhoc_kdf(&prk_4e3m, 7u8, &th_4_buf, th_4.len(), SHA256_DIGEST_LEN);
+                            prk_out[..SHA256_DIGEST_LEN]
+                                .copy_from_slice(&prk_out_buf[..SHA256_DIGEST_LEN]);
+
+                            // compute prk_exporter from prk_out
+                            // PRK_exporter  = EDHOC-KDF( PRK_out, 10, h'', hash_length )
+                            let prk_exporter_buf = edhoc_kdf(
+                                &prk_out,
+                                10u8,
+                                &[0x00u8; MAX_KDF_CONTEXT_LEN],
+                                0,
+                                SHA256_DIGEST_LEN,
+                            );
+                            prk_exporter[..SHA256_DIGEST_LEN]
+                                .copy_from_slice(&prk_exporter_buf[..SHA256_DIGEST_LEN]);
+
+                            error = EDHOCError::Success;
+                            current_state = EDHOCState::Completed;
+
+                            state = construct_state(
+                                current_state,
+                                y,
+                                _c_i,
+                                _g_x,
+                                prk_3e2m,
+                                prk_4e3m,
+                                prk_out,
+                                prk_exporter,
+                                _h_message_1,
+                                th_3,
+                            );
+                        } else {
+                            error = EDHOCError::MacVerificationFailed;
+                        }
                     } else {
-                        error = EDHOCError::MacVerificationFailed;
+                        error = EDHOCError::UnknownPeer;
                     }
                 } else {
-                    error = EDHOCError::UnknownPeer;
+                    error = EDHOCError::EADError;
                 }
             } else {
                 error = decoded_p3_res.unwrap_err();
@@ -334,6 +355,8 @@ pub fn i_prepare_message_1(
         // Choose a connection identifier C_I and store it for the length of the protocol.
         c_i = C_I;
 
+        let ead_1 = i_prepare_ead_1();
+
         // Encode message_1 as a sequence of CBOR encoded data items as specified in Section 5.2.1
         message_1 = encode_message_1(
             EDHOC_METHOD,
@@ -341,7 +364,7 @@ pub fn i_prepare_message_1(
             EDHOC_SUPPORTED_SUITES.len(),
             &g_x,
             c_i,
-            &None::<EADItem>,
+            &ead_1,
         );
 
         let mut message_1_buf: BytesMaxBuffer = [0x00; MAX_BUFFER_LEN];
@@ -420,57 +443,67 @@ pub fn i_process_message_2(
             let plaintext_2_decoded = decode_plaintext_2(&plaintext_2, plaintext_2_len);
 
             if plaintext_2_decoded.is_ok() {
-                let (kid, mac_2, _ead_2) = plaintext_2_decoded.unwrap();
+                let (kid, mac_2, ead_2) = plaintext_2_decoded.unwrap();
 
-                // verify mac_2
-                let salt_3e2m = compute_salt_3e2m(&prk_2e, &th_2);
+                // Step 3: If EAD is present make it available to the application
+                let ead_success = if let Some(ead_2) = ead_2 {
+                    i_process_ead_2(ead_2).is_ok()
+                } else {
+                    true
+                };
+                if ead_success {
+                    // verify mac_2
+                    let salt_3e2m = compute_salt_3e2m(&prk_2e, &th_2);
 
-                prk_3e2m = compute_prk_3e2m(&salt_3e2m, &x, g_r);
+                    prk_3e2m = compute_prk_3e2m(&salt_3e2m, &x, g_r);
 
-                let expected_mac_2 = compute_mac_2(
-                    &prk_3e2m,
-                    id_cred_r_expected,
-                    cred_r_expected,
-                    cred_r_len,
-                    &th_2,
-                );
+                    let expected_mac_2 = compute_mac_2(
+                        &prk_3e2m,
+                        id_cred_r_expected,
+                        cred_r_expected,
+                        cred_r_len,
+                        &th_2,
+                    );
 
-                if mac_2 == expected_mac_2 {
-                    if kid == id_cred_r_expected[id_cred_r_expected.len() - 1] {
-                        // step is actually from processing of message_3
-                        // but we do it here to avoid storing plaintext_2 in State
-                        let mut pt2: BufferPlaintext2 = BufferPlaintext2::new();
-                        pt2.content[..plaintext_2_len]
-                            .copy_from_slice(&plaintext_2[..plaintext_2_len]);
-                        pt2.len = plaintext_2_len;
-                        th_3 = compute_th_3(&th_2, &pt2, cred_r_expected, cred_r_len);
-                        // message 3 processing
+                    if mac_2 == expected_mac_2 {
+                        if kid == id_cred_r_expected[id_cred_r_expected.len() - 1] {
+                            // step is actually from processing of message_3
+                            // but we do it here to avoid storing plaintext_2 in State
+                            let mut pt2: BufferPlaintext2 = BufferPlaintext2::new();
+                            pt2.content[..plaintext_2_len]
+                                .copy_from_slice(&plaintext_2[..plaintext_2_len]);
+                            pt2.len = plaintext_2_len;
+                            th_3 = compute_th_3(&th_2, &pt2, cred_r_expected, cred_r_len);
+                            // message 3 processing
 
-                        let salt_4e3m = compute_salt_4e3m(&prk_3e2m, &th_3);
+                            let salt_4e3m = compute_salt_4e3m(&prk_3e2m, &th_3);
 
-                        prk_4e3m = compute_prk_4e3m(&salt_4e3m, i, &g_y);
+                            prk_4e3m = compute_prk_4e3m(&salt_4e3m, i, &g_y);
 
-                        error = EDHOCError::Success;
-                        current_state = EDHOCState::ProcessedMessage2;
+                            error = EDHOCError::Success;
+                            current_state = EDHOCState::ProcessedMessage2;
 
-                        state = construct_state(
-                            current_state,
-                            x,
-                            _c_i,
-                            g_y,
-                            prk_3e2m,
-                            prk_4e3m,
-                            _prk_out,
-                            _prk_exporter,
-                            h_message_1,
-                            th_3,
-                        );
+                            state = construct_state(
+                                current_state,
+                                x,
+                                _c_i,
+                                g_y,
+                                prk_3e2m,
+                                prk_4e3m,
+                                _prk_out,
+                                _prk_exporter,
+                                h_message_1,
+                                th_3,
+                            );
+                        } else {
+                            // Unknown peer
+                            error = EDHOCError::UnknownPeer;
+                        }
                     } else {
-                        // Unknown peer
-                        error = EDHOCError::UnknownPeer;
+                        error = EDHOCError::MacVerificationFailed;
                     }
                 } else {
-                    error = EDHOCError::MacVerificationFailed;
+                    error = EDHOCError::EADError;
                 }
             } else {
                 error = EDHOCError::ParsingError;
@@ -512,7 +545,10 @@ pub fn i_prepare_message_3(
 
     if current_state == EDHOCState::ProcessedMessage2 {
         let mac_3 = compute_mac_3(&prk_4e3m, &th_3, id_cred_i, cred_i, cred_i_len);
-        let plaintext_3 = encode_plaintext_3(id_cred_i, &mac_3, &None::<EADItem>);
+
+        let ead_3 = i_prepare_ead_3();
+
+        let plaintext_3 = encode_plaintext_3(id_cred_i, &mac_3, &ead_3);
         message_3 = encrypt_message_3(&prk_3e2m, &th_3, &plaintext_3);
 
         let th_4 = compute_th_4(&th_3, &plaintext_3, cred_i, cred_i_len);

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -668,4 +668,5 @@ mod test {
         assert_eq!(i_oscore_secret.unwrap(), r_oscore_secret.unwrap());
         assert_eq!(i_oscore_salt.unwrap(), r_oscore_salt.unwrap());
     }
+
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -22,6 +22,9 @@ pub use {
     rust::RustEdhocInitiator as EdhocInitiator, rust::RustEdhocResponder as EdhocResponder,
 };
 
+#[cfg(feature = "ead-zeroconf")]
+pub use edhoc_ead::*;
+
 #[cfg(any(
     feature = "rust-psa",
     feature = "rust-psa-baremetal",
@@ -669,4 +672,40 @@ mod test {
         assert_eq!(i_oscore_salt.unwrap(), r_oscore_salt.unwrap());
     }
 
+#[cfg(any(
+    feature = "ead-zeroconf",
+))]
+#[test]
+    fn test_ead() {
+        let state_initiator: EdhocState = Default::default();
+        let mut initiator = EdhocInitiator::new(
+            state_initiator,
+            I,
+            G_R,
+            ID_CRED_I,
+            CRED_I,
+            ID_CRED_R,
+            CRED_R,
+        );
+        let state_responder: EdhocState = Default::default();
+        let mut responder = EdhocResponder::new(
+            state_responder,
+            R,
+            G_I,
+            ID_CRED_I,
+            CRED_I,
+            ID_CRED_R,
+            CRED_R,
+        );
+
+        ead_set_global_state(EADState::new());
+
+        let ead_state = ead_get_global_state();
+        assert!(ead_state.protocol_state == EADInitiatorProtocolState::Start);
+
+        initiator.prepare_message_1().unwrap();
+
+        let ead_state = ead_get_global_state();
+        assert!(ead_state.protocol_state == EADInitiatorProtocolState::WaitEAD2);
+    }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -672,8 +672,8 @@ mod test {
         assert_eq!(i_oscore_salt.unwrap(), r_oscore_salt.unwrap());
     }
 
-#[cfg(feature = "ead-zeroconf")]
-#[test]
+    #[cfg(feature = "ead-zeroconf")]
+    #[test]
     fn test_ead() {
         let state_initiator: EdhocState = Default::default();
         let mut initiator = EdhocInitiator::new(
@@ -698,28 +698,49 @@ mod test {
 
         ead_initiator_set_global_state(EADInitiatorState::new());
         let ead_initiator_state = ead_initiator_get_global_state();
-        assert_eq!(ead_initiator_state.protocol_state, EADInitiatorProtocolState::Start);
+        assert_eq!(
+            ead_initiator_state.protocol_state,
+            EADInitiatorProtocolState::Start
+        );
 
         ead_responder_set_global_state(EADResponderState::new());
         let ead_responder_state = ead_responder_get_global_state();
-        assert_eq!(ead_responder_state.protocol_state, EADResponderProtocolState::Start);
+        assert_eq!(
+            ead_responder_state.protocol_state,
+            EADResponderProtocolState::Start
+        );
 
         let message_1 = initiator.prepare_message_1().unwrap();
-        assert_eq!(ead_initiator_state.protocol_state, EADInitiatorProtocolState::WaitEAD2);
+        assert_eq!(
+            ead_initiator_state.protocol_state,
+            EADInitiatorProtocolState::WaitEAD2
+        );
 
         responder.process_message_1(&message_1).unwrap();
-        assert_eq!(ead_responder_state.protocol_state, EADResponderProtocolState::ProcessedEAD1);
+        assert_eq!(
+            ead_responder_state.protocol_state,
+            EADResponderProtocolState::ProcessedEAD1
+        );
 
         let (message_2, _c_r) = responder.prepare_message_2().unwrap();
-        assert_eq!(ead_responder_state.protocol_state, EADResponderProtocolState::Completed);
+        assert_eq!(
+            ead_responder_state.protocol_state,
+            EADResponderProtocolState::Completed
+        );
 
         initiator.process_message_2(&message_2).unwrap();
-        assert_eq!(ead_initiator_state.protocol_state, EADInitiatorProtocolState::Completed);
+        assert_eq!(
+            ead_initiator_state.protocol_state,
+            EADInitiatorProtocolState::Completed
+        );
 
         let (message_3, i_prk_out) = initiator.prepare_message_3().unwrap();
 
         let r_prk_out = responder.process_message_3(&message_3).unwrap();
         assert_eq!(i_prk_out, r_prk_out);
-        assert_eq!(ead_responder_state.protocol_state, EADResponderProtocolState::Completed);
+        assert_eq!(
+            ead_responder_state.protocol_state,
+            EADResponderProtocolState::Completed
+        );
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -22,7 +22,7 @@ pub use {
     rust::RustEdhocInitiator as EdhocInitiator, rust::RustEdhocResponder as EdhocResponder,
 };
 
-#[cfg(feature = "ead-zeroconf")]
+#[cfg(any(feature = "ead-none", feature = "ead-zeroconf"))]
 pub use edhoc_ead::*;
 
 #[cfg(any(


### PR DESCRIPTION
Addressing #67.

This PR introduces a new crate, `edhoc-ead`, which has two subcrates: `edhoc-ead-none` and `edhoc-ead-zeroconf`. The former is a default placeholder that provides mocked functions to satisfy Rust's compiler, while the latter provides a skeleton implementation for the [lake-authz draft](https://ericssonresearch.github.io/ace-ake-authz/draft-selander-lake-authz.html). This structure is just like what is used with `edhoc-crypto` to enable multiple crypto backends.

Some remarks:
- achieved goal of keeping stack-only allocations
- in the current approach, only one EAD handler implementation is supported, e.g., `edhoc-rs` can be compiled with one of: `ead-none`, `ead-zeroconf`, `ead-foobar`, etc.
- currently, the EAD state is global and mutable, and not in a thread safe way -- should not be a problem for now since we only have single-threaded code, but could be improved.