### PR TITLE
Update dependencies that broke CI

### DIFF
--- a/crypto/edhoc-crypto-cc2538/Cargo.toml
+++ b/crypto/edhoc-crypto-cc2538/Cargo.toml
@@ -13,8 +13,8 @@ cortex-m = { version = "0.7.4" }
 cortex-m-rt = { version = "0.7.1" }
 cortex-m-semihosting = { version = "0.5.0" }
 panic-semihosting = { version = "0.6.0", features = ["exit"] }
-cc2538-pac = { version = "0.1.0", features = ["rt"] }
-cc2538-hal = { git = "https://github.com/thvdveld/cc2538-hal/", branch = "crypto" }
+cc2538-pac = { version = "0.4.0", features = ["rt"] }
+cc2538-hal = "0.2.0"
 
 # depend on an allocator
 static-alloc = { version = "0.2.3", optional = true }

--- a/examples/coap/Cargo.toml
+++ b/examples/coap/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 edhoc-rs = { path = "../../lib", features = [ "hacspec-hacspec" ] }
-coap = { version = "0.12" }
-coap-lite = { version = "0.9.1" }
+coap = { version = "0.13" }
+coap-lite = { version = "0.11.3" }

--- a/examples/edhoc-rs-cc2538/Cargo.toml
+++ b/examples/edhoc-rs-cc2538/Cargo.toml
@@ -11,8 +11,8 @@ edhoc-rs = { path = "../../lib", default-features = false }
 # depend on an allocator
 embedded-alloc = "0.5.0"
 hexlit = "0.5.3"
-cc2538-pac = { version = "0.1.0", features = ["rt"] }
-cc2538-hal = { git = "https://github.com/thvdveld/cc2538-hal/", branch = "crypto" }
+cc2538-pac = { version = "0.4.0", features = ["rt"] }
+cc2538-hal = "0.2.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7", features = ["device"] }
 panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }

--- a/examples/edhoc-rs-cc2538/src/main.rs
+++ b/examples/edhoc-rs-cc2538/src/main.rs
@@ -65,7 +65,7 @@ fn inner_main() -> Result<(), &'static str> {
     const G_R: &str = "bbc34960526ea4d32e940cad2a234148ddc21791a12afbcbac93622046dd44f0";
     const C_R_TV: [u8; 1] = hex!("27");
 
-    let mut periph = pac::Peripherals::take().ok_or("unable to get peripherals")?;
+    let mut periph = unsafe { pac::Peripherals::steal() };
 
     let mut core_periph = cortex_m::Peripherals::take().unwrap();
     core_periph.DCB.enable_trace();


### PR DESCRIPTION
With https://github.com/thvdveld/cc2538-hal/pull/2 closed, cc2538-hal now has a published 0.2.0 that contains the crypto code we previously had a git branch dependency on.

This should fix the build failures that started when the PR was closed and the branch removed.

The -pac crate is updated in lockstep with -hal's dependency to avoid duplicates; the `.take().expect(...)` idiom is exchanged with an unsafe `.steal()` following the examples of cc2538-hal.

Contributes-To: https://github.com/openwsn-berkeley/edhoc-rs/pull/98

CC'ing @thvdveld who is probably the best person to review this.