### PR TITLE
"Crypto as trait" experiments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crypto/edhoc-crypto-hacspec",
   "crypto/edhoc-crypto-psa",
   "crypto/edhoc-crypto-cryptocell310-sys",
+  "crypto/edhoc-crypto-trait",
   "examples/coap",
   "examples/edhoc-rs-no_std",
   "examples/edhoc-rs-cc2538",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -9,6 +9,8 @@ description = "EDHOC crypto library dispatch crate"
 [dependencies]
 edhoc-consts = { path = "../consts", default-features = false }
 
+edhoc-crypto-trait.path = "./edhoc-crypto-trait"
+
 # hacspec
 edhoc-crypto-hacspec = { path = "./edhoc-crypto-hacspec", optional = true }
 

--- a/crypto/edhoc-crypto-cryptocell310-sys/Cargo.toml
+++ b/crypto/edhoc-crypto-cryptocell310-sys/Cargo.toml
@@ -9,6 +9,7 @@ links = "nrf_cc310_0.9.13"
 
 [dependencies]
 edhoc-consts = { path = "../../consts" }
+edhoc-crypto-trait.path = "../edhoc-crypto-trait"
 
 [build-dependencies]
 bindgen = "0.63.0"

--- a/crypto/edhoc-crypto-cryptocell310-sys/src/lib.rs
+++ b/crypto/edhoc-crypto-cryptocell310-sys/src/lib.rs
@@ -23,265 +23,264 @@ fn convert_array(input: &[u32]) -> [u8; SHA256_DIGEST_LEN] {
 pub struct Crypto;
 
 impl CryptoTrait for Crypto {
+    fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
+        let mut buffer: [u32; 64 / 4] = [0x00; 64 / 4];
 
-fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
-    let mut buffer: [u32; 64 / 4] = [0x00; 64 / 4];
+        unsafe {
+            CRYS_HASH(
+                CRYS_HASH_OperationMode_t_CRYS_HASH_SHA256_mode,
+                message.clone().as_mut_ptr(),
+                message_len,
+                buffer.as_mut_ptr(),
+            );
+        }
 
-    unsafe {
-        CRYS_HASH(
-            CRYS_HASH_OperationMode_t_CRYS_HASH_SHA256_mode,
-            message.clone().as_mut_ptr(),
-            message_len,
-            buffer.as_mut_ptr(),
-        );
+        convert_array(&buffer[0..SHA256_DIGEST_LEN / 4])
     }
 
-    convert_array(&buffer[0..SHA256_DIGEST_LEN / 4])
-}
+    fn hkdf_expand(
+        prk: &BytesHashLen,
+        info: &BytesMaxInfoBuffer,
+        info_len: usize,
+        length: usize,
+    ) -> BytesMaxBuffer {
+        let mut buffer = [0x00u8; MAX_BUFFER_LEN];
+        unsafe {
+            CRYS_HKDF_KeyDerivFunc(
+                CRYS_HKDF_HASH_OpMode_t_CRYS_HKDF_HASH_SHA256_mode,
+                core::ptr::null_mut(),
+                0 as usize,
+                prk.clone().as_mut_ptr(),
+                prk.len() as u32,
+                info.clone().as_mut_ptr(),
+                info_len as u32,
+                buffer.as_mut_ptr(),
+                length as u32,
+                SaSiBool_SASI_TRUE,
+            );
+        }
 
-fn hkdf_expand(
-    prk: &BytesHashLen,
-    info: &BytesMaxInfoBuffer,
-    info_len: usize,
-    length: usize,
-) -> BytesMaxBuffer {
-    let mut buffer = [0x00u8; MAX_BUFFER_LEN];
-    unsafe {
-        CRYS_HKDF_KeyDerivFunc(
-            CRYS_HKDF_HASH_OpMode_t_CRYS_HKDF_HASH_SHA256_mode,
-            core::ptr::null_mut(),
-            0 as usize,
-            prk.clone().as_mut_ptr(),
-            prk.len() as u32,
-            info.clone().as_mut_ptr(),
-            info_len as u32,
-            buffer.as_mut_ptr(),
-            length as u32,
-            SaSiBool_SASI_TRUE,
-        );
+        buffer
     }
 
-    buffer
-}
+    fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen {
+        // Implementation of HKDF-Extract as per RFC 5869
 
-fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen {
-    // Implementation of HKDF-Extract as per RFC 5869
+        // TODO generalize if salt is not provided
+        let output = hmac_sha256(&mut ikm.clone()[..], *salt);
 
-    // TODO generalize if salt is not provided
-    let output = hmac_sha256(&mut ikm.clone()[..], *salt);
+        output
+    }
 
-    output
-}
+    fn aes_ccm_encrypt_tag_8(
+        key: &BytesCcmKeyLen,
+        iv: &BytesCcmIvLen,
+        ad: &BytesEncStructureLen,
+        plaintext: &BufferPlaintext3,
+    ) -> BufferCiphertext3 {
+        let mut output: BufferCiphertext3 = BufferCiphertext3::new();
+        let mut tag: CRYS_AESCCM_Mac_Res_t = Default::default();
+        let mut aesccm_key: CRYS_AESCCM_Key_t = Default::default();
 
-fn aes_ccm_encrypt_tag_8(
-    key: &BytesCcmKeyLen,
-    iv: &BytesCcmIvLen,
-    ad: &BytesEncStructureLen,
-    plaintext: &BufferPlaintext3,
-) -> BufferCiphertext3 {
-    let mut output: BufferCiphertext3 = BufferCiphertext3::new();
-    let mut tag: CRYS_AESCCM_Mac_Res_t = Default::default();
-    let mut aesccm_key: CRYS_AESCCM_Key_t = Default::default();
+        aesccm_key[0..AES_CCM_KEY_LEN].copy_from_slice(&key[..]);
 
-    aesccm_key[0..AES_CCM_KEY_LEN].copy_from_slice(&key[..]);
+        let err = unsafe {
+            CC_AESCCM(
+                SaSiAesEncryptMode_t_SASI_AES_ENCRYPT,
+                aesccm_key.as_mut_ptr(),
+                CRYS_AESCCM_KeySize_t_CRYS_AES_Key128BitSize,
+                iv.clone().as_mut_ptr(),
+                iv.len() as u8,
+                ad.clone().as_mut_ptr(),
+                ad.len() as u32,
+                plaintext.content.clone().as_mut_ptr(),
+                plaintext.len as u32,
+                output.content.as_mut_ptr(),
+                AES_CCM_TAG_LEN as u8, // authentication tag length
+                tag.as_mut_ptr(),
+                0 as u32, // CCM
+            )
+        };
 
-    let err = unsafe {
-        CC_AESCCM(
-            SaSiAesEncryptMode_t_SASI_AES_ENCRYPT,
-            aesccm_key.as_mut_ptr(),
-            CRYS_AESCCM_KeySize_t_CRYS_AES_Key128BitSize,
-            iv.clone().as_mut_ptr(),
-            iv.len() as u8,
-            ad.clone().as_mut_ptr(),
-            ad.len() as u32,
-            plaintext.content.clone().as_mut_ptr(),
-            plaintext.len as u32,
-            output.content.as_mut_ptr(),
-            AES_CCM_TAG_LEN as u8, // authentication tag length
-            tag.as_mut_ptr(),
-            0 as u32, // CCM
-        )
-    };
+        output.content[plaintext.len..plaintext.len + AES_CCM_TAG_LEN]
+            .copy_from_slice(&tag[..AES_CCM_TAG_LEN]);
+        output.len = plaintext.len + AES_CCM_TAG_LEN;
 
-    output.content[plaintext.len..plaintext.len + AES_CCM_TAG_LEN]
-        .copy_from_slice(&tag[..AES_CCM_TAG_LEN]);
-    output.len = plaintext.len + AES_CCM_TAG_LEN;
+        output
+    }
 
-    output
-}
+    fn aes_ccm_decrypt_tag_8(
+        key: &BytesCcmKeyLen,
+        iv: &BytesCcmIvLen,
+        ad: &BytesEncStructureLen,
+        ciphertext: &BufferCiphertext3,
+    ) -> Result<BufferPlaintext3, EDHOCError> {
+        let mut output: BufferPlaintext3 = BufferPlaintext3::new();
+        let mut aesccm_key: CRYS_AESCCM_Key_t = Default::default();
 
-fn aes_ccm_decrypt_tag_8(
-    key: &BytesCcmKeyLen,
-    iv: &BytesCcmIvLen,
-    ad: &BytesEncStructureLen,
-    ciphertext: &BufferCiphertext3,
-) -> Result<BufferPlaintext3, EDHOCError> {
-    let mut output: BufferPlaintext3 = BufferPlaintext3::new();
-    let mut aesccm_key: CRYS_AESCCM_Key_t = Default::default();
+        aesccm_key[0..AES_CCM_KEY_LEN].copy_from_slice(&key[..]);
 
-    aesccm_key[0..AES_CCM_KEY_LEN].copy_from_slice(&key[..]);
+        let mut err = EDHOCError::MacVerificationFailed;
 
-    let mut err = EDHOCError::MacVerificationFailed;
-
-    unsafe {
-        match CC_AESCCM(
-            SaSiAesEncryptMode_t_SASI_AES_DECRYPT,
-            aesccm_key.as_mut_ptr(),
-            CRYS_AESCCM_KeySize_t_CRYS_AES_Key128BitSize,
-            iv.clone().as_mut_ptr(),
-            iv.len() as u8,
-            ad.clone().as_mut_ptr(),
-            ad.len() as u32,
-            ciphertext.content.clone().as_mut_ptr(),
-            (ciphertext.len - AES_CCM_TAG_LEN) as u32,
-            output.content.as_mut_ptr(),
-            AES_CCM_TAG_LEN as u8, // authentication tag length
-            ciphertext.content.clone()[ciphertext.len - AES_CCM_TAG_LEN..].as_mut_ptr(),
-            0 as u32, // CCM
-        ) {
-            CRYS_OK => {
-                output.len = ciphertext.len - AES_CCM_TAG_LEN;
-                Ok(output)
+        unsafe {
+            match CC_AESCCM(
+                SaSiAesEncryptMode_t_SASI_AES_DECRYPT,
+                aesccm_key.as_mut_ptr(),
+                CRYS_AESCCM_KeySize_t_CRYS_AES_Key128BitSize,
+                iv.clone().as_mut_ptr(),
+                iv.len() as u8,
+                ad.clone().as_mut_ptr(),
+                ad.len() as u32,
+                ciphertext.content.clone().as_mut_ptr(),
+                (ciphertext.len - AES_CCM_TAG_LEN) as u32,
+                output.content.as_mut_ptr(),
+                AES_CCM_TAG_LEN as u8, // authentication tag length
+                ciphertext.content.clone()[ciphertext.len - AES_CCM_TAG_LEN..].as_mut_ptr(),
+                0 as u32, // CCM
+            ) {
+                CRYS_OK => {
+                    output.len = ciphertext.len - AES_CCM_TAG_LEN;
+                    Ok(output)
+                }
+                _ => Err(EDHOCError::MacVerificationFailed),
             }
-            _ => Err(EDHOCError::MacVerificationFailed),
         }
     }
-}
 
-fn p256_ecdh(
-    private_key: &BytesP256ElemLen,
-    public_key: &BytesP256ElemLen,
-) -> BytesP256ElemLen {
-    let mut output = [0x0u8; P256_ELEM_LEN];
-    let mut output_len: u32 = output.len() as u32;
+    fn p256_ecdh(
+        private_key: &BytesP256ElemLen,
+        public_key: &BytesP256ElemLen,
+    ) -> BytesP256ElemLen {
+        let mut output = [0x0u8; P256_ELEM_LEN];
+        let mut output_len: u32 = output.len() as u32;
 
-    let mut tmp: CRYS_ECDH_TempData_t = Default::default();
+        let mut tmp: CRYS_ECDH_TempData_t = Default::default();
 
-    let mut public_key_compressed = [0x0u8; P256_ELEM_LEN + 1];
-    public_key_compressed[0] = 0x02;
-    public_key_compressed[1..].copy_from_slice(&public_key[..]);
+        let mut public_key_compressed = [0x0u8; P256_ELEM_LEN + 1];
+        public_key_compressed[0] = 0x02;
+        public_key_compressed[1..].copy_from_slice(&public_key[..]);
 
-    let mut public_key_cc310: CRYS_ECPKI_UserPublKey_t = Default::default();
+        let mut public_key_cc310: CRYS_ECPKI_UserPublKey_t = Default::default();
 
-    let mut domain =
-        unsafe { CRYS_ECPKI_GetEcDomain(CRYS_ECPKI_DomainID_t_CRYS_ECPKI_DomainID_secp256r1) };
+        let mut domain =
+            unsafe { CRYS_ECPKI_GetEcDomain(CRYS_ECPKI_DomainID_t_CRYS_ECPKI_DomainID_secp256r1) };
 
-    unsafe {
-        _DX_ECPKI_BuildPublKey(
-            domain,
-            public_key_compressed.as_mut_ptr(),
-            (P256_ELEM_LEN + 1) as u32,
-            EC_PublKeyCheckMode_t_CheckPointersAndSizesOnly,
-            &mut public_key_cc310,
-            core::ptr::null_mut(),
-        );
+        unsafe {
+            _DX_ECPKI_BuildPublKey(
+                domain,
+                public_key_compressed.as_mut_ptr(),
+                (P256_ELEM_LEN + 1) as u32,
+                EC_PublKeyCheckMode_t_CheckPointersAndSizesOnly,
+                &mut public_key_cc310,
+                core::ptr::null_mut(),
+            );
+        }
+
+        let mut private_key_cc310: CRYS_ECPKI_UserPrivKey_t = Default::default();
+
+        unsafe {
+            CRYS_ECPKI_BuildPrivKey(
+                domain,
+                private_key.clone().as_mut_ptr(),
+                P256_ELEM_LEN as u32,
+                &mut private_key_cc310,
+            );
+        }
+
+        unsafe {
+            CRYS_ECDH_SVDP_DH(
+                &mut public_key_cc310,
+                &mut private_key_cc310,
+                output.as_mut_ptr(),
+                &mut output_len,
+                &mut tmp,
+            );
+        }
+
+        output
     }
 
-    let mut private_key_cc310: CRYS_ECPKI_UserPrivKey_t = Default::default();
-
-    unsafe {
-        CRYS_ECPKI_BuildPrivKey(
-            domain,
-            private_key.clone().as_mut_ptr(),
-            P256_ELEM_LEN as u32,
-            &mut private_key_cc310,
-        );
+    fn get_random_byte() -> u8 {
+        let mut rnd_context = CRYS_RND_State_t::default();
+        let mut rnd_work_buffer = CRYS_RND_WorkBuff_t::default();
+        unsafe {
+            SaSi_LibInit();
+            CRYS_RndInit(
+                &mut rnd_context as *mut _ as *mut c_void,
+                &mut rnd_work_buffer as *mut _,
+            );
+        }
+        let mut buffer = [0u8; 1];
+        unsafe {
+            CRYS_RND_GenerateVector(
+                &mut rnd_context as *mut _ as *mut c_void,
+                1,
+                buffer.as_mut_ptr(),
+            );
+        }
+        buffer[0]
     }
 
-    unsafe {
-        CRYS_ECDH_SVDP_DH(
-            &mut public_key_cc310,
-            &mut private_key_cc310,
-            output.as_mut_ptr(),
-            &mut output_len,
-            &mut tmp,
-        );
+    fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen) {
+        let mut rnd_context = CRYS_RND_State_t::default();
+        let mut rnd_work_buffer = CRYS_RND_WorkBuff_t::default();
+        unsafe {
+            SaSi_LibInit();
+            CRYS_RndInit(
+                &mut rnd_context as *mut _ as *mut c_void,
+                &mut rnd_work_buffer as *mut _,
+            );
+        }
+        let rnd_generate_vect_func: SaSiRndGenerateVectWorkFunc_t = Some(CRYS_RND_GenerateVector);
+        let mut curve_256 =
+            unsafe { CRYS_ECPKI_GetEcDomain(CRYS_ECPKI_DomainID_t_CRYS_ECPKI_DomainID_secp256r1) };
+        let mut crys_private_key: *mut CRYS_ECPKI_UserPrivKey_t =
+            &mut CRYS_ECPKI_UserPrivKey_t::default();
+        let mut crys_public_key: *mut CRYS_ECPKI_UserPublKey_t =
+            &mut CRYS_ECPKI_UserPublKey_t::default();
+        let mut temp_data: *mut CRYS_ECPKI_KG_TempData_t = &mut CRYS_ECPKI_KG_TempData_t::default();
+        let mut temp_fips_buffer: *mut CRYS_ECPKI_KG_FipsContext_t =
+            &mut CRYS_ECPKI_KG_FipsContext_t::default();
+
+        unsafe {
+            CRYS_ECPKI_GenKeyPair(
+                &mut rnd_context as *mut _ as *mut c_void,
+                rnd_generate_vect_func,
+                curve_256,
+                crys_private_key,
+                crys_public_key,
+                temp_data,
+                temp_fips_buffer,
+            );
+        }
+
+        let mut private_key: [u8; P256_ELEM_LEN] = [0x0; P256_ELEM_LEN];
+        let mut key_size: u32 = P256_ELEM_LEN.try_into().unwrap();
+
+        unsafe {
+            CRYS_ECPKI_ExportPrivKey(crys_private_key, private_key.as_mut_ptr(), &mut key_size);
+        }
+
+        // let private_key = BytesP256ElemLen::from_public_slice(&private_key[..]);
+
+        let mut public_key: [u8; P256_ELEM_LEN + 1] = [0x0; P256_ELEM_LEN + 1];
+        let mut key_size: u32 = (P256_ELEM_LEN as u32) + 1;
+        let compressed_flag: CRYS_ECPKI_PointCompression_t =
+            CRYS_ECPKI_PointCompression_t_CRYS_EC_PointCompressed;
+
+        unsafe {
+            CRYS_ECPKI_ExportPublKey(
+                crys_public_key,
+                compressed_flag,
+                public_key.as_mut_ptr(),
+                &mut key_size,
+            );
+        }
+
+        let public_key: [u8; P256_ELEM_LEN] = public_key[1..33].try_into().unwrap(); // discard sign byte
+
+        (private_key, public_key)
     }
-
-    output
-}
-
-fn get_random_byte() -> u8 {
-    let mut rnd_context = CRYS_RND_State_t::default();
-    let mut rnd_work_buffer = CRYS_RND_WorkBuff_t::default();
-    unsafe {
-        SaSi_LibInit();
-        CRYS_RndInit(
-            &mut rnd_context as *mut _ as *mut c_void,
-            &mut rnd_work_buffer as *mut _,
-        );
-    }
-    let mut buffer = [0u8; 1];
-    unsafe {
-        CRYS_RND_GenerateVector(
-            &mut rnd_context as *mut _ as *mut c_void,
-            1,
-            buffer.as_mut_ptr(),
-        );
-    }
-    buffer[0]
-}
-
-fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen) {
-    let mut rnd_context = CRYS_RND_State_t::default();
-    let mut rnd_work_buffer = CRYS_RND_WorkBuff_t::default();
-    unsafe {
-        SaSi_LibInit();
-        CRYS_RndInit(
-            &mut rnd_context as *mut _ as *mut c_void,
-            &mut rnd_work_buffer as *mut _,
-        );
-    }
-    let rnd_generate_vect_func: SaSiRndGenerateVectWorkFunc_t = Some(CRYS_RND_GenerateVector);
-    let mut curve_256 =
-        unsafe { CRYS_ECPKI_GetEcDomain(CRYS_ECPKI_DomainID_t_CRYS_ECPKI_DomainID_secp256r1) };
-    let mut crys_private_key: *mut CRYS_ECPKI_UserPrivKey_t =
-        &mut CRYS_ECPKI_UserPrivKey_t::default();
-    let mut crys_public_key: *mut CRYS_ECPKI_UserPublKey_t =
-        &mut CRYS_ECPKI_UserPublKey_t::default();
-    let mut temp_data: *mut CRYS_ECPKI_KG_TempData_t = &mut CRYS_ECPKI_KG_TempData_t::default();
-    let mut temp_fips_buffer: *mut CRYS_ECPKI_KG_FipsContext_t =
-        &mut CRYS_ECPKI_KG_FipsContext_t::default();
-
-    unsafe {
-        CRYS_ECPKI_GenKeyPair(
-            &mut rnd_context as *mut _ as *mut c_void,
-            rnd_generate_vect_func,
-            curve_256,
-            crys_private_key,
-            crys_public_key,
-            temp_data,
-            temp_fips_buffer,
-        );
-    }
-
-    let mut private_key: [u8; P256_ELEM_LEN] = [0x0; P256_ELEM_LEN];
-    let mut key_size: u32 = P256_ELEM_LEN.try_into().unwrap();
-
-    unsafe {
-        CRYS_ECPKI_ExportPrivKey(crys_private_key, private_key.as_mut_ptr(), &mut key_size);
-    }
-
-    // let private_key = BytesP256ElemLen::from_public_slice(&private_key[..]);
-
-    let mut public_key: [u8; P256_ELEM_LEN + 1] = [0x0; P256_ELEM_LEN + 1];
-    let mut key_size: u32 = (P256_ELEM_LEN as u32) + 1;
-    let compressed_flag: CRYS_ECPKI_PointCompression_t =
-        CRYS_ECPKI_PointCompression_t_CRYS_EC_PointCompressed;
-
-    unsafe {
-        CRYS_ECPKI_ExportPublKey(
-            crys_public_key,
-            compressed_flag,
-            public_key.as_mut_ptr(),
-            &mut key_size,
-        );
-    }
-
-    let public_key: [u8; P256_ELEM_LEN] = public_key[1..33].try_into().unwrap(); // discard sign byte
-
-    (private_key, public_key)
-}
 }
 
 fn hmac_sha256(message: &mut [u8], mut key: [u8; SHA256_DIGEST_LEN]) -> BytesHashLen {

--- a/crypto/edhoc-crypto-cryptocell310-sys/src/lib.rs
+++ b/crypto/edhoc-crypto-cryptocell310-sys/src/lib.rs
@@ -23,7 +23,7 @@ fn convert_array(input: &[u32]) -> [u8; SHA256_DIGEST_LEN] {
 pub struct Crypto;
 
 impl CryptoTrait for Crypto {
-    fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
+    fn sha256_digest(&mut self, message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
         let mut buffer: [u32; 64 / 4] = [0x00; 64 / 4];
 
         unsafe {
@@ -39,6 +39,7 @@ impl CryptoTrait for Crypto {
     }
 
     fn hkdf_expand(
+        &mut self,
         prk: &BytesHashLen,
         info: &BytesMaxInfoBuffer,
         info_len: usize,
@@ -63,7 +64,7 @@ impl CryptoTrait for Crypto {
         buffer
     }
 
-    fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen {
+    fn hkdf_extract(&mut self, salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen {
         // Implementation of HKDF-Extract as per RFC 5869
 
         // TODO generalize if salt is not provided
@@ -73,6 +74,7 @@ impl CryptoTrait for Crypto {
     }
 
     fn aes_ccm_encrypt_tag_8(
+        &mut self,
         key: &BytesCcmKeyLen,
         iv: &BytesCcmIvLen,
         ad: &BytesEncStructureLen,
@@ -110,6 +112,7 @@ impl CryptoTrait for Crypto {
     }
 
     fn aes_ccm_decrypt_tag_8(
+        &mut self,
         key: &BytesCcmKeyLen,
         iv: &BytesCcmIvLen,
         ad: &BytesEncStructureLen,
@@ -148,6 +151,7 @@ impl CryptoTrait for Crypto {
     }
 
     fn p256_ecdh(
+        &mut self,
         private_key: &BytesP256ElemLen,
         public_key: &BytesP256ElemLen,
     ) -> BytesP256ElemLen {
@@ -200,7 +204,7 @@ impl CryptoTrait for Crypto {
         output
     }
 
-    fn get_random_byte() -> u8 {
+    fn get_random_byte(&mut self) -> u8 {
         let mut rnd_context = CRYS_RND_State_t::default();
         let mut rnd_work_buffer = CRYS_RND_WorkBuff_t::default();
         unsafe {
@@ -221,7 +225,7 @@ impl CryptoTrait for Crypto {
         buffer[0]
     }
 
-    fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen) {
+    fn p256_generate_key_pair(&mut self) -> (BytesP256ElemLen, BytesP256ElemLen) {
         let mut rnd_context = CRYS_RND_State_t::default();
         let mut rnd_work_buffer = CRYS_RND_WorkBuff_t::default();
         unsafe {

--- a/crypto/edhoc-crypto-hacspec/Cargo.toml
+++ b/crypto/edhoc-crypto-hacspec/Cargo.toml
@@ -8,6 +8,7 @@ description = "EDHOC crypto library hacspec backend"
 
 [dependencies]
 edhoc-consts = { path = "../../consts", default-features = false }
+edhoc-crypto-trait.path = "../edhoc-crypto-trait"
 hacspec-lib = { version = "0.1.0-beta.1", default-features = false }
 hacspec-p256 = { version = "0.1.0" }
 hacspec-hkdf = { version = "0.1.0" }

--- a/crypto/edhoc-crypto-hacspec/src/lib.rs
+++ b/crypto/edhoc-crypto-hacspec/src/lib.rs
@@ -9,6 +9,8 @@ use hacspec_p256::*;
 use hacspec_sha256::*;
 use rand::Rng;
 
+use edhoc_crypto_trait::Crypto as CryptoTrait;
+
 // Types and functions to aid in translation between the hacspec and non-hacspec world
 
 // TODO: the `array!` construct is not needed anymore.
@@ -70,7 +72,11 @@ type BufferPlaintext3Hacspec = EdhocMessageBufferHacspec;
 
 // Public functions
 
-pub fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
+pub struct Crypto;
+
+impl CryptoTrait for Crypto {
+
+fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
     let message: BytesMaxBufferHacspec = BytesMaxBufferHacspec::from_public_slice(message);
 
     let output =
@@ -79,7 +85,7 @@ pub fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashL
     output.to_public_array()
 }
 
-pub fn hkdf_expand(
+fn hkdf_expand(
     prk: &BytesHashLen,
     info: &BytesMaxInfoBuffer,
     info_len: usize,
@@ -102,7 +108,7 @@ pub fn hkdf_expand(
     output.to_public_array()
 }
 
-pub fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen {
+fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen {
     let output = BytesHashLenHacspec::from_seq(&extract(
         &ByteSeq::from_slice(&BytesHashLenHacspec::from_public_slice(salt), 0, salt.len()),
         &ByteSeq::from_slice(
@@ -114,7 +120,7 @@ pub fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen
     output.to_public_array()
 }
 
-pub fn aes_ccm_encrypt_tag_8(
+fn aes_ccm_encrypt_tag_8(
     key: &BytesCcmKeyLen,
     iv: &BytesCcmIvLen,
     ad: &BytesEncStructureLen,
@@ -137,7 +143,7 @@ pub fn aes_ccm_encrypt_tag_8(
     output.to_public_buffer()
 }
 
-pub fn aes_ccm_decrypt_tag_8(
+fn aes_ccm_decrypt_tag_8(
     key: &BytesCcmKeyLen,
     iv: &BytesCcmIvLen,
     ad: &BytesEncStructureLen,
@@ -162,7 +168,7 @@ pub fn aes_ccm_decrypt_tag_8(
     }
 }
 
-pub fn p256_ecdh(
+fn p256_ecdh(
     private_key: &BytesP256ElemLen,
     public_key: &BytesP256ElemLen,
 ) -> BytesP256ElemLen {
@@ -184,12 +190,12 @@ pub fn p256_ecdh(
 }
 
 #[cfg(not(feature = "hacspec-pure"))]
-pub fn get_random_byte() -> u8 {
+fn get_random_byte() -> u8 {
     rand::thread_rng().gen::<u8>()
 }
 
 #[cfg(not(feature = "hacspec-pure"))]
-pub fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen) {
+fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen) {
     // generate a private key
     let mut private_key = BytesP256ElemLenHacspec::new();
     loop {
@@ -209,13 +215,15 @@ pub fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen) {
     (private_key.to_public_array(), public_key.to_public_array())
 }
 
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_p256_keys() {
-        let (x, g_x) = p256_generate_key_pair();
+        let (x, g_x) = Crypto::p256_generate_key_pair();
         assert_eq!(x.len(), 32);
         assert_eq!(g_x.len(), 32);
 

--- a/crypto/edhoc-crypto-hacspec/src/lib.rs
+++ b/crypto/edhoc-crypto-hacspec/src/lib.rs
@@ -75,7 +75,7 @@ type BufferPlaintext3Hacspec = EdhocMessageBufferHacspec;
 pub struct Crypto;
 
 impl CryptoTrait for Crypto {
-    fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
+    fn sha256_digest(&mut self, message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
         let message: BytesMaxBufferHacspec = BytesMaxBufferHacspec::from_public_slice(message);
 
         let output =
@@ -85,6 +85,7 @@ impl CryptoTrait for Crypto {
     }
 
     fn hkdf_expand(
+        &mut self,
         prk: &BytesHashLen,
         info: &BytesMaxInfoBuffer,
         info_len: usize,
@@ -107,7 +108,7 @@ impl CryptoTrait for Crypto {
         output.to_public_array()
     }
 
-    fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen {
+    fn hkdf_extract(&mut self, salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen {
         let output = BytesHashLenHacspec::from_seq(&extract(
             &ByteSeq::from_slice(&BytesHashLenHacspec::from_public_slice(salt), 0, salt.len()),
             &ByteSeq::from_slice(
@@ -120,6 +121,7 @@ impl CryptoTrait for Crypto {
     }
 
     fn aes_ccm_encrypt_tag_8(
+        &mut self,
         key: &BytesCcmKeyLen,
         iv: &BytesCcmIvLen,
         ad: &BytesEncStructureLen,
@@ -143,6 +145,7 @@ impl CryptoTrait for Crypto {
     }
 
     fn aes_ccm_decrypt_tag_8(
+        &mut self,
         key: &BytesCcmKeyLen,
         iv: &BytesCcmIvLen,
         ad: &BytesEncStructureLen,
@@ -168,6 +171,7 @@ impl CryptoTrait for Crypto {
     }
 
     fn p256_ecdh(
+        &mut self,
         private_key: &BytesP256ElemLen,
         public_key: &BytesP256ElemLen,
     ) -> BytesP256ElemLen {
@@ -189,12 +193,12 @@ impl CryptoTrait for Crypto {
     }
 
     #[cfg(not(feature = "hacspec-pure"))]
-    fn get_random_byte() -> u8 {
+    fn get_random_byte(&mut self) -> u8 {
         rand::thread_rng().gen::<u8>()
     }
 
     #[cfg(not(feature = "hacspec-pure"))]
-    fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen) {
+    fn p256_generate_key_pair(&mut self) -> (BytesP256ElemLen, BytesP256ElemLen) {
         // generate a private key
         let mut private_key = BytesP256ElemLenHacspec::new();
         loop {
@@ -221,14 +225,14 @@ mod tests {
 
     #[test]
     fn test_p256_keys() {
-        let (x, g_x) = Crypto::p256_generate_key_pair();
+        let (x, g_x) = Crypto.p256_generate_key_pair();
         assert_eq!(x.len(), 32);
         assert_eq!(g_x.len(), 32);
 
-        let (y, g_y) = p256_generate_key_pair();
+        let (y, g_y) = Crypto.p256_generate_key_pair();
 
-        let g_xy = p256_ecdh(&x, &g_y);
-        let g_yx = p256_ecdh(&y, &g_x);
+        let g_xy = Crypto.p256_ecdh(&x, &g_y);
+        let g_yx = Crypto.p256_ecdh(&y, &g_x);
 
         assert_eq!(g_xy, g_yx);
     }

--- a/crypto/edhoc-crypto-psa/Cargo.toml
+++ b/crypto/edhoc-crypto-psa/Cargo.toml
@@ -8,6 +8,7 @@ description = "EDHOC crypto library PSA backend"
 
 [dependencies]
 edhoc-consts = { path = "../../consts" }
+edhoc-crypto-trait.path = "../edhoc-crypto-trait"
 psa-crypto = { version = "0.9.2" }
 
 [features]

--- a/crypto/edhoc-crypto-psa/src/lib.rs
+++ b/crypto/edhoc-crypto-psa/src/lib.rs
@@ -25,219 +25,219 @@ pub extern "C" fn mbedtls_hardware_poll(
 pub struct Crypto;
 
 impl CryptoTrait for Crypto {
+    fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
+        let hash_alg = Hash::Sha256;
+        let mut hash: [u8; SHA256_DIGEST_LEN] = [0; SHA256_DIGEST_LEN];
+        psa_crypto::init().unwrap();
+        hash_compute(hash_alg, &message[..message_len], &mut hash).unwrap();
 
-fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
-    let hash_alg = Hash::Sha256;
-    let mut hash: [u8; SHA256_DIGEST_LEN] = [0; SHA256_DIGEST_LEN];
-    psa_crypto::init().unwrap();
-    hash_compute(hash_alg, &message[..message_len], &mut hash).unwrap();
-
-    hash
-}
-
-// FIXME: Together with hkdf_extract, and the hmac_sha256 helper, this could be a provided
-// function.
-fn hkdf_expand(
-    prk: &BytesHashLen,
-    info: &BytesMaxInfoBuffer,
-    info_len: usize,
-    length: usize,
-) -> BytesMaxBuffer {
-    // Implementation of HKDF-Expand as per RFC5869
-
-    let mut output: [u8; MAX_BUFFER_LEN] = [0; MAX_BUFFER_LEN];
-
-    let mut n = 0;
-
-    // N = ceil(L/HashLen)
-    if length % SHA256_DIGEST_LEN == 0 {
-        n = length / SHA256_DIGEST_LEN;
-    } else {
-        n = length / SHA256_DIGEST_LEN + 1;
+        hash
     }
 
-    let mut message: [u8; MAX_INFO_LEN + SHA256_DIGEST_LEN + 1] =
-        [0; MAX_INFO_LEN + SHA256_DIGEST_LEN + 1];
-    message[..info_len].copy_from_slice(&info[..info_len]);
-    message[info_len] = 0x01;
-    let mut t_i = hmac_sha256(&message[..info_len + 1], prk);
-    output[..SHA256_DIGEST_LEN].copy_from_slice(&t_i);
+    // FIXME: Together with hkdf_extract, and the hmac_sha256 helper, this could be a provided
+    // function.
+    fn hkdf_expand(
+        prk: &BytesHashLen,
+        info: &BytesMaxInfoBuffer,
+        info_len: usize,
+        length: usize,
+    ) -> BytesMaxBuffer {
+        // Implementation of HKDF-Expand as per RFC5869
 
-    for i in 2..n {
-        message[..SHA256_DIGEST_LEN].copy_from_slice(&t_i);
-        message[SHA256_DIGEST_LEN..SHA256_DIGEST_LEN + info_len].copy_from_slice(&info[..info_len]);
-        message[SHA256_DIGEST_LEN + info_len] = i as u8;
-        t_i = hmac_sha256(&message[..SHA256_DIGEST_LEN + info_len + 1], prk);
-        output[i * SHA256_DIGEST_LEN..(i + 1) * SHA256_DIGEST_LEN].copy_from_slice(&t_i);
-    }
+        let mut output: [u8; MAX_BUFFER_LEN] = [0; MAX_BUFFER_LEN];
 
-    output[length..].fill(0x00);
+        let mut n = 0;
 
-    output
-}
-
-fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen {
-    // Implementation of HKDF-Extract as per RFC 5869
-
-    // TODO generalize if salt is not provided
-    let output = hmac_sha256(ikm, salt);
-
-    output
-}
-
-fn aes_ccm_encrypt_tag_8(
-    key: &BytesCcmKeyLen,
-    iv: &BytesCcmIvLen,
-    ad: &BytesEncStructureLen,
-    plaintext: &BufferPlaintext3,
-) -> BufferCiphertext3 {
-    psa_crypto::init().unwrap();
-
-    let alg = Aead::AeadWithShortenedTag {
-        aead_alg: AeadWithDefaultLengthTag::Ccm,
-        tag_length: 8,
-    };
-    let mut usage_flags: UsageFlags = Default::default();
-    usage_flags.set_encrypt();
-
-    let attributes = Attributes {
-        key_type: Type::Aes,
-        bits: 128,
-        lifetime: Lifetime::Volatile,
-        policy: Policy {
-            usage_flags,
-            permitted_algorithms: alg.into(),
-        },
-    };
-    let my_key = key_management::import(attributes, None, &key[..]).unwrap();
-    let mut output_buffer: BufferCiphertext3 = BufferCiphertext3::new();
-
-    aead::encrypt(
-        my_key,
-        alg,
-        iv,
-        ad,
-        &plaintext.content[..plaintext.len],
-        &mut output_buffer.content,
-    )
-    .unwrap();
-
-    output_buffer.len = plaintext.len + AES_CCM_TAG_LEN;
-    output_buffer
-}
-
-fn aes_ccm_decrypt_tag_8(
-    key: &BytesCcmKeyLen,
-    iv: &BytesCcmIvLen,
-    ad: &BytesEncStructureLen,
-    ciphertext: &BufferCiphertext3,
-) -> Result<BufferPlaintext3, EDHOCError> {
-    psa_crypto::init().unwrap();
-
-    let alg = Aead::AeadWithShortenedTag {
-        aead_alg: AeadWithDefaultLengthTag::Ccm,
-        tag_length: 8,
-    };
-    let mut usage_flags: UsageFlags = Default::default();
-    usage_flags.set_decrypt();
-
-    let attributes = Attributes {
-        key_type: Type::Aes,
-        bits: 128,
-        lifetime: Lifetime::Volatile,
-        policy: Policy {
-            usage_flags,
-            permitted_algorithms: alg.into(),
-        },
-    };
-    let my_key = key_management::import(attributes, None, &key[..]).unwrap();
-    let mut output_buffer: BufferPlaintext3 = BufferPlaintext3::new();
-
-    match aead::decrypt(
-        my_key,
-        alg,
-        iv,
-        ad,
-        &ciphertext.content[..ciphertext.len],
-        &mut output_buffer.content,
-    ) {
-        Ok(_) => {
-            output_buffer.len = ciphertext.len - AES_CCM_TAG_LEN;
-            Ok(output_buffer)
+        // N = ceil(L/HashLen)
+        if length % SHA256_DIGEST_LEN == 0 {
+            n = length / SHA256_DIGEST_LEN;
+        } else {
+            n = length / SHA256_DIGEST_LEN + 1;
         }
-        Err(_) => Err(EDHOCError::MacVerificationFailed),
+
+        let mut message: [u8; MAX_INFO_LEN + SHA256_DIGEST_LEN + 1] =
+            [0; MAX_INFO_LEN + SHA256_DIGEST_LEN + 1];
+        message[..info_len].copy_from_slice(&info[..info_len]);
+        message[info_len] = 0x01;
+        let mut t_i = hmac_sha256(&message[..info_len + 1], prk);
+        output[..SHA256_DIGEST_LEN].copy_from_slice(&t_i);
+
+        for i in 2..n {
+            message[..SHA256_DIGEST_LEN].copy_from_slice(&t_i);
+            message[SHA256_DIGEST_LEN..SHA256_DIGEST_LEN + info_len]
+                .copy_from_slice(&info[..info_len]);
+            message[SHA256_DIGEST_LEN + info_len] = i as u8;
+            t_i = hmac_sha256(&message[..SHA256_DIGEST_LEN + info_len + 1], prk);
+            output[i * SHA256_DIGEST_LEN..(i + 1) * SHA256_DIGEST_LEN].copy_from_slice(&t_i);
+        }
+
+        output[length..].fill(0x00);
+
+        output
     }
-}
 
-fn p256_ecdh(
-    private_key: &BytesP256ElemLen,
-    public_key: &BytesP256ElemLen,
-) -> BytesP256ElemLen {
-    let mut peer_public_key: [u8; 33] = [0; 33];
-    peer_public_key[0] = 0x02; // sign does not matter for ECDH operation
-    peer_public_key[1..33].copy_from_slice(&public_key[..]);
+    fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen {
+        // Implementation of HKDF-Extract as per RFC 5869
 
-    let alg = RawKeyAgreement::Ecdh;
-    let mut usage_flags: UsageFlags = Default::default();
-    usage_flags.set_derive();
-    let attributes = Attributes {
-        key_type: Type::EccKeyPair {
-            curve_family: EccFamily::SecpR1,
-        },
-        bits: 256,
-        lifetime: Lifetime::Volatile,
-        policy: Policy {
-            usage_flags,
-            permitted_algorithms: KeyAgreement::Raw(alg).into(),
-        },
-    };
+        // TODO generalize if salt is not provided
+        let output = hmac_sha256(ikm, salt);
 
-    psa_crypto::init().unwrap();
-    let my_key = key_management::import(attributes, None, private_key).unwrap();
-    let mut output_buffer: [u8; P256_ELEM_LEN] = [0; P256_ELEM_LEN];
+        output
+    }
 
-    key_agreement::raw_key_agreement(alg, my_key, &peer_public_key, &mut output_buffer).unwrap();
+    fn aes_ccm_encrypt_tag_8(
+        key: &BytesCcmKeyLen,
+        iv: &BytesCcmIvLen,
+        ad: &BytesEncStructureLen,
+        plaintext: &BufferPlaintext3,
+    ) -> BufferCiphertext3 {
+        psa_crypto::init().unwrap();
 
-    output_buffer
-}
+        let alg = Aead::AeadWithShortenedTag {
+            aead_alg: AeadWithDefaultLengthTag::Ccm,
+            tag_length: 8,
+        };
+        let mut usage_flags: UsageFlags = Default::default();
+        usage_flags.set_encrypt();
 
-fn get_random_byte() -> u8 {
-    psa_crypto::init().unwrap();
-    let mut buffer = [0u8; 1];
-    generate_random(&mut buffer); // TODO: check return value
-    buffer[0]
-}
+        let attributes = Attributes {
+            key_type: Type::Aes,
+            bits: 128,
+            lifetime: Lifetime::Volatile,
+            policy: Policy {
+                usage_flags,
+                permitted_algorithms: alg.into(),
+            },
+        };
+        let my_key = key_management::import(attributes, None, &key[..]).unwrap();
+        let mut output_buffer: BufferCiphertext3 = BufferCiphertext3::new();
 
-fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen) {
-    let alg = RawKeyAgreement::Ecdh;
-    let mut usage_flags: UsageFlags = UsageFlags::default();
-    usage_flags.set_export();
-    usage_flags.set_derive();
-    let attributes = Attributes {
-        key_type: Type::EccKeyPair {
-            curve_family: EccFamily::SecpR1,
-        },
-        bits: 256,
-        lifetime: Lifetime::Volatile,
-        policy: Policy {
-            usage_flags,
-            permitted_algorithms: KeyAgreement::Raw(alg).into(),
-        },
-    };
+        aead::encrypt(
+            my_key,
+            alg,
+            iv,
+            ad,
+            &plaintext.content[..plaintext.len],
+            &mut output_buffer.content,
+        )
+        .unwrap();
 
-    psa_crypto::init().unwrap();
+        output_buffer.len = plaintext.len + AES_CCM_TAG_LEN;
+        output_buffer
+    }
 
-    let key_id = key_management::generate(attributes, None).unwrap();
-    let mut private_key: [u8; P256_ELEM_LEN] = [0; P256_ELEM_LEN];
-    key_management::export(key_id, &mut private_key).unwrap();
+    fn aes_ccm_decrypt_tag_8(
+        key: &BytesCcmKeyLen,
+        iv: &BytesCcmIvLen,
+        ad: &BytesEncStructureLen,
+        ciphertext: &BufferCiphertext3,
+    ) -> Result<BufferPlaintext3, EDHOCError> {
+        psa_crypto::init().unwrap();
 
-    let mut public_key: [u8; P256_ELEM_LEN * 2 + 1] = [0; P256_ELEM_LEN * 2 + 1]; // allocate buffer for: sign, x, and y coordinates
-    key_management::export_public(key_id, &mut public_key).unwrap();
-    let public_key: [u8; P256_ELEM_LEN] = public_key[1..33].try_into().unwrap(); // return only the x coordinate
+        let alg = Aead::AeadWithShortenedTag {
+            aead_alg: AeadWithDefaultLengthTag::Ccm,
+            tag_length: 8,
+        };
+        let mut usage_flags: UsageFlags = Default::default();
+        usage_flags.set_decrypt();
 
-    (private_key, public_key)
-}
+        let attributes = Attributes {
+            key_type: Type::Aes,
+            bits: 128,
+            lifetime: Lifetime::Volatile,
+            policy: Policy {
+                usage_flags,
+                permitted_algorithms: alg.into(),
+            },
+        };
+        let my_key = key_management::import(attributes, None, &key[..]).unwrap();
+        let mut output_buffer: BufferPlaintext3 = BufferPlaintext3::new();
 
+        match aead::decrypt(
+            my_key,
+            alg,
+            iv,
+            ad,
+            &ciphertext.content[..ciphertext.len],
+            &mut output_buffer.content,
+        ) {
+            Ok(_) => {
+                output_buffer.len = ciphertext.len - AES_CCM_TAG_LEN;
+                Ok(output_buffer)
+            }
+            Err(_) => Err(EDHOCError::MacVerificationFailed),
+        }
+    }
+
+    fn p256_ecdh(
+        private_key: &BytesP256ElemLen,
+        public_key: &BytesP256ElemLen,
+    ) -> BytesP256ElemLen {
+        let mut peer_public_key: [u8; 33] = [0; 33];
+        peer_public_key[0] = 0x02; // sign does not matter for ECDH operation
+        peer_public_key[1..33].copy_from_slice(&public_key[..]);
+
+        let alg = RawKeyAgreement::Ecdh;
+        let mut usage_flags: UsageFlags = Default::default();
+        usage_flags.set_derive();
+        let attributes = Attributes {
+            key_type: Type::EccKeyPair {
+                curve_family: EccFamily::SecpR1,
+            },
+            bits: 256,
+            lifetime: Lifetime::Volatile,
+            policy: Policy {
+                usage_flags,
+                permitted_algorithms: KeyAgreement::Raw(alg).into(),
+            },
+        };
+
+        psa_crypto::init().unwrap();
+        let my_key = key_management::import(attributes, None, private_key).unwrap();
+        let mut output_buffer: [u8; P256_ELEM_LEN] = [0; P256_ELEM_LEN];
+
+        key_agreement::raw_key_agreement(alg, my_key, &peer_public_key, &mut output_buffer)
+            .unwrap();
+
+        output_buffer
+    }
+
+    fn get_random_byte() -> u8 {
+        psa_crypto::init().unwrap();
+        let mut buffer = [0u8; 1];
+        generate_random(&mut buffer); // TODO: check return value
+        buffer[0]
+    }
+
+    fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen) {
+        let alg = RawKeyAgreement::Ecdh;
+        let mut usage_flags: UsageFlags = UsageFlags::default();
+        usage_flags.set_export();
+        usage_flags.set_derive();
+        let attributes = Attributes {
+            key_type: Type::EccKeyPair {
+                curve_family: EccFamily::SecpR1,
+            },
+            bits: 256,
+            lifetime: Lifetime::Volatile,
+            policy: Policy {
+                usage_flags,
+                permitted_algorithms: KeyAgreement::Raw(alg).into(),
+            },
+        };
+
+        psa_crypto::init().unwrap();
+
+        let key_id = key_management::generate(attributes, None).unwrap();
+        let mut private_key: [u8; P256_ELEM_LEN] = [0; P256_ELEM_LEN];
+        key_management::export(key_id, &mut private_key).unwrap();
+
+        let mut public_key: [u8; P256_ELEM_LEN * 2 + 1] = [0; P256_ELEM_LEN * 2 + 1]; // allocate buffer for: sign, x, and y coordinates
+        key_management::export_public(key_id, &mut public_key).unwrap();
+        let public_key: [u8; P256_ELEM_LEN] = public_key[1..33].try_into().unwrap(); // return only the x coordinate
+
+        (private_key, public_key)
+    }
 }
 
 fn hmac_sha256(message: &[u8], key: &[u8; SHA256_DIGEST_LEN]) -> BytesHashLen {

--- a/crypto/edhoc-crypto-psa/src/lib.rs
+++ b/crypto/edhoc-crypto-psa/src/lib.rs
@@ -7,6 +7,8 @@ use psa_crypto::types::algorithm::Hash;
 use psa_crypto::types::algorithm::{Aead, AeadWithDefaultLengthTag, KeyAgreement, RawKeyAgreement};
 use psa_crypto::types::key::{Attributes, EccFamily, Lifetime, Policy, Type, UsageFlags};
 
+use edhoc_crypto_trait::Crypto as CryptoTrait;
+
 #[no_mangle]
 pub extern "C" fn mbedtls_hardware_poll(
     data: *mut ::core::ffi::c_void,
@@ -20,7 +22,11 @@ pub extern "C" fn mbedtls_hardware_poll(
     0i32
 }
 
-pub fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
+pub struct Crypto;
+
+impl CryptoTrait for Crypto {
+
+fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
     let hash_alg = Hash::Sha256;
     let mut hash: [u8; SHA256_DIGEST_LEN] = [0; SHA256_DIGEST_LEN];
     psa_crypto::init().unwrap();
@@ -29,7 +35,9 @@ pub fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashL
     hash
 }
 
-pub fn hkdf_expand(
+// FIXME: Together with hkdf_extract, and the hmac_sha256 helper, this could be a provided
+// function.
+fn hkdf_expand(
     prk: &BytesHashLen,
     info: &BytesMaxInfoBuffer,
     info_len: usize,
@@ -68,7 +76,7 @@ pub fn hkdf_expand(
     output
 }
 
-pub fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen {
+fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen {
     // Implementation of HKDF-Extract as per RFC 5869
 
     // TODO generalize if salt is not provided
@@ -77,7 +85,7 @@ pub fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen
     output
 }
 
-pub fn aes_ccm_encrypt_tag_8(
+fn aes_ccm_encrypt_tag_8(
     key: &BytesCcmKeyLen,
     iv: &BytesCcmIvLen,
     ad: &BytesEncStructureLen,
@@ -118,7 +126,7 @@ pub fn aes_ccm_encrypt_tag_8(
     output_buffer
 }
 
-pub fn aes_ccm_decrypt_tag_8(
+fn aes_ccm_decrypt_tag_8(
     key: &BytesCcmKeyLen,
     iv: &BytesCcmIvLen,
     ad: &BytesEncStructureLen,
@@ -161,7 +169,7 @@ pub fn aes_ccm_decrypt_tag_8(
     }
 }
 
-pub fn p256_ecdh(
+fn p256_ecdh(
     private_key: &BytesP256ElemLen,
     public_key: &BytesP256ElemLen,
 ) -> BytesP256ElemLen {
@@ -193,57 +201,14 @@ pub fn p256_ecdh(
     output_buffer
 }
 
-pub fn hmac_sha256(message: &[u8], key: &[u8; SHA256_DIGEST_LEN]) -> BytesHashLen {
-    // implementation of HMAC as per RFC2104
-
-    const IPAD: [u8; 64] = [0x36; 64];
-    const OPAD: [u8; 64] = [0x5C; 64];
-
-    //    (1) append zeros to the end of K to create a B byte string
-    //        (e.g., if K is of length 20 bytes and B=64, then K will be
-    //         appended with 44 zero bytes 0x00)
-    let mut b: [u8; MAX_BUFFER_LEN] = [0; MAX_BUFFER_LEN];
-    b[0..SHA256_DIGEST_LEN].copy_from_slice(&key[..]);
-
-    //    (2) XOR (bitwise exclusive-OR) the B byte string computed in step
-    //        (1) with ipad
-    let mut s2: [u8; MAX_BUFFER_LEN] = [0; MAX_BUFFER_LEN];
-    for i in 0..64 {
-        s2[i] = b[i] ^ IPAD[i];
-    }
-
-    //    (3) append the stream of data 'text' to the B byte string resulting
-    //        from step (2)
-    s2[64..64 + message.len()].copy_from_slice(message);
-
-    //    (4) apply H to the stream generated in step (3)
-    let ih = sha256_digest(&s2, 64 + message.len());
-
-    //    (5) XOR (bitwise exclusive-OR) the B byte string computed in
-    //        step (1) with opad
-    let mut s5: [u8; MAX_BUFFER_LEN] = [0; MAX_BUFFER_LEN];
-    for i in 0..64 {
-        s5[i] = b[i] ^ OPAD[i];
-    }
-    //    (6) append the H result from step (4) to the B byte string
-    //        resulting from step (5)
-    s5[64..64 + SHA256_DIGEST_LEN].copy_from_slice(&ih);
-
-    //    (7) apply H to the stream generated in step (6) and output
-    //        the result
-    let oh = sha256_digest(&s5, 3 * SHA256_DIGEST_LEN);
-
-    oh
-}
-
-pub fn get_random_byte() -> u8 {
+fn get_random_byte() -> u8 {
     psa_crypto::init().unwrap();
     let mut buffer = [0u8; 1];
     generate_random(&mut buffer); // TODO: check return value
     buffer[0]
 }
 
-pub fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen) {
+fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen) {
     let alg = RawKeyAgreement::Ecdh;
     let mut usage_flags: UsageFlags = UsageFlags::default();
     usage_flags.set_export();
@@ -271,6 +236,51 @@ pub fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen) {
     let public_key: [u8; P256_ELEM_LEN] = public_key[1..33].try_into().unwrap(); // return only the x coordinate
 
     (private_key, public_key)
+}
+
+}
+
+fn hmac_sha256(message: &[u8], key: &[u8; SHA256_DIGEST_LEN]) -> BytesHashLen {
+    // implementation of HMAC as per RFC2104
+
+    const IPAD: [u8; 64] = [0x36; 64];
+    const OPAD: [u8; 64] = [0x5C; 64];
+
+    //    (1) append zeros to the end of K to create a B byte string
+    //        (e.g., if K is of length 20 bytes and B=64, then K will be
+    //         appended with 44 zero bytes 0x00)
+    let mut b: [u8; MAX_BUFFER_LEN] = [0; MAX_BUFFER_LEN];
+    b[0..SHA256_DIGEST_LEN].copy_from_slice(&key[..]);
+
+    //    (2) XOR (bitwise exclusive-OR) the B byte string computed in step
+    //        (1) with ipad
+    let mut s2: [u8; MAX_BUFFER_LEN] = [0; MAX_BUFFER_LEN];
+    for i in 0..64 {
+        s2[i] = b[i] ^ IPAD[i];
+    }
+
+    //    (3) append the stream of data 'text' to the B byte string resulting
+    //        from step (2)
+    s2[64..64 + message.len()].copy_from_slice(message);
+
+    //    (4) apply H to the stream generated in step (3)
+    let ih = Crypto::sha256_digest(&s2, 64 + message.len());
+
+    //    (5) XOR (bitwise exclusive-OR) the B byte string computed in
+    //        step (1) with opad
+    let mut s5: [u8; MAX_BUFFER_LEN] = [0; MAX_BUFFER_LEN];
+    for i in 0..64 {
+        s5[i] = b[i] ^ OPAD[i];
+    }
+    //    (6) append the H result from step (4) to the B byte string
+    //        resulting from step (5)
+    s5[64..64 + SHA256_DIGEST_LEN].copy_from_slice(&ih);
+
+    //    (7) apply H to the stream generated in step (6) and output
+    //        the result
+    let oh = Crypto::sha256_digest(&s5, 3 * SHA256_DIGEST_LEN);
+
+    oh
 }
 
 #[cfg(test)]

--- a/crypto/edhoc-crypto-trait/Cargo.toml
+++ b/crypto/edhoc-crypto-trait/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "edhoc-crypto-trait"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+edhoc-consts = { path = "../../consts", default-features = false }

--- a/crypto/edhoc-crypto-trait/src/lib.rs
+++ b/crypto/edhoc-crypto-trait/src/lib.rs
@@ -1,0 +1,31 @@
+//! Cryptography trait back-end for the edhoc-crypto crate
+#![no_std]
+
+use edhoc_consts::*;
+
+pub trait Crypto {
+    fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen;
+    fn hkdf_expand(
+        prk: &BytesHashLen,
+        info: &BytesMaxInfoBuffer,
+        info_len: usize,
+        length: usize,
+    ) -> BytesMaxBuffer;
+    fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen;
+    fn aes_ccm_encrypt_tag_8(
+        key: &BytesCcmKeyLen,
+        iv: &BytesCcmIvLen,
+        ad: &BytesEncStructureLen,
+        plaintext: &BufferPlaintext3,
+    ) -> BufferCiphertext3;
+    fn aes_ccm_decrypt_tag_8(
+        key: &BytesCcmKeyLen,
+        iv: &BytesCcmIvLen,
+        ad: &BytesEncStructureLen,
+        ciphertext: &BufferCiphertext3,
+    ) -> Result<BufferPlaintext3, EDHOCError>;
+    fn p256_ecdh(private_key: &BytesP256ElemLen, public_key: &BytesP256ElemLen)
+        -> BytesP256ElemLen;
+    fn get_random_byte() -> u8;
+    fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen);
+}

--- a/crypto/edhoc-crypto-trait/src/lib.rs
+++ b/crypto/edhoc-crypto-trait/src/lib.rs
@@ -4,28 +4,34 @@
 use edhoc_consts::*;
 
 pub trait Crypto {
-    fn sha256_digest(message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen;
+    fn sha256_digest(&mut self, message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen;
     fn hkdf_expand(
+        &mut self,
         prk: &BytesHashLen,
         info: &BytesMaxInfoBuffer,
         info_len: usize,
         length: usize,
     ) -> BytesMaxBuffer;
-    fn hkdf_extract(salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen;
+    fn hkdf_extract(&mut self, salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen;
     fn aes_ccm_encrypt_tag_8(
+        &mut self,
         key: &BytesCcmKeyLen,
         iv: &BytesCcmIvLen,
         ad: &BytesEncStructureLen,
         plaintext: &BufferPlaintext3,
     ) -> BufferCiphertext3;
     fn aes_ccm_decrypt_tag_8(
+        &mut self,
         key: &BytesCcmKeyLen,
         iv: &BytesCcmIvLen,
         ad: &BytesEncStructureLen,
         ciphertext: &BufferCiphertext3,
     ) -> Result<BufferPlaintext3, EDHOCError>;
-    fn p256_ecdh(private_key: &BytesP256ElemLen, public_key: &BytesP256ElemLen)
-        -> BytesP256ElemLen;
-    fn get_random_byte() -> u8;
-    fn p256_generate_key_pair() -> (BytesP256ElemLen, BytesP256ElemLen);
+    fn p256_ecdh(
+        &mut self,
+        private_key: &BytesP256ElemLen,
+        public_key: &BytesP256ElemLen,
+    ) -> BytesP256ElemLen;
+    fn get_random_byte(&mut self) -> u8;
+    fn p256_generate_key_pair(&mut self) -> (BytesP256ElemLen, BytesP256ElemLen);
 }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -12,6 +12,11 @@ pub use edhoc_crypto_trait::Crypto as CryptoTrait;
 #[cfg(feature = "hacspec")]
 pub type Crypto = edhoc_crypto_hacspec::Crypto;
 
+#[cfg(feature = "hacspec")]
+pub const fn default_crypto() -> Crypto {
+    edhoc_crypto_hacspec::Crypto
+}
+
 // FIXME: Does not work with crypto-as-trait yet
 #[cfg(feature = "cc2538")]
 pub use edhoc_crypto_cc2538::*;
@@ -19,8 +24,18 @@ pub use edhoc_crypto_cc2538::*;
 #[cfg(any(feature = "psa", feature = "psa-rust",))]
 pub type Crypto = edhoc_crypto_psa::Crypto;
 
+#[cfg(any(feature = "psa", feature = "psa-rust",))]
+pub const fn default_crypto() -> Crypto {
+    edhoc_crypto_psa::Crypto
+}
+
 #[cfg(any(feature = "cryptocell310", feature = "cryptocell310-rust"))]
 pub type Crypto = edhoc_crypto_cryptocell310::Crypto;
+
+#[cfg(any(feature = "cryptocell310", feature = "cryptocell310-rust"))]
+pub const fn default_crypto() -> Crypto {
+    edhoc_crypto_cryptocell310::Crypto
+}
 
 /// See test_implements_crypto
 #[allow(dead_code)]

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,13 +1,34 @@
+//! Cryptography dispatch for the edhoc-rs crate
+//!
+//! This crate is used by edhoc-rs to decide which cryptographic back-end to use. Its presence
+//! avoids the need for all edhoc-rs types to be generic over a back-end, which would then be
+//! provided by the user at initialization time. On the long run, its type may turn into a
+//! default associated type.
 #![no_std]
 
-#[cfg(feature = "hacspec")]
-pub use edhoc_crypto_hacspec::*;
+/// Convenience re-export
+pub use edhoc_crypto_trait::Crypto as CryptoTrait;
 
+#[cfg(feature = "hacspec")]
+pub type Crypto = edhoc_crypto_hacspec::Crypto;
+
+// FIXME: Does not work with crypto-as-trait yet
 #[cfg(feature = "cc2538")]
 pub use edhoc_crypto_cc2538::*;
 
 #[cfg(any(feature = "psa", feature = "psa-rust",))]
-pub use edhoc_crypto_psa::*;
+pub type Crypto = edhoc_crypto_psa::Crypto;
 
 #[cfg(any(feature = "cryptocell310", feature = "cryptocell310-rust"))]
-pub use edhoc_crypto_cryptocell310::*;
+pub type Crypto = edhoc_crypto_cryptocell310::Crypto;
+
+/// See test_implements_crypto
+#[allow(dead_code)]
+fn test_helper<T: CryptoTrait>() {}
+
+/// Ensure at build time that whichever type as selected for Crypto actually implements the Crypto
+/// trait, and that one is actually defined.
+#[allow(dead_code)]
+fn test_implements_crypto() {
+    test_helper::<Crypto>()
+}

--- a/examples/edhoc-rs-no_std/Cargo.toml
+++ b/examples/edhoc-rs-no_std/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 edhoc-rs = { path = "../../lib", default-features = false }
+edhoc-crypto = { path = "../../crypto", default-features = false }
 hexlit = "0.5.3"
 
 # depend on an allocator

--- a/examples/edhoc-rs-no_std/src/main.rs
+++ b/examples/edhoc-rs-no_std/src/main.rs
@@ -13,6 +13,7 @@ use panic_semihosting as _;
 #[cfg(feature = "rtt")]
 use rtt_target::{rprintln as println, rtt_init_print};
 
+use edhoc_crypto::{Crypto, CryptoTrait};
 use edhoc_rs::*;
 
 extern crate alloc;
@@ -80,11 +81,11 @@ fn main() -> ! {
     println!("Test test_new_initiator passed.");
 
     fn test_p256_keys() {
-        let (x, g_x) = p256_generate_key_pair();
-        let (y, g_y) = p256_generate_key_pair();
+        let (x, g_x) = Crypto::p256_generate_key_pair();
+        let (y, g_y) = Crypto::p256_generate_key_pair();
 
-        let g_xy = p256_ecdh(&x, &g_y);
-        let g_yx = p256_ecdh(&y, &g_x);
+        let g_xy = Crypto::p256_ecdh(&x, &g_y);
+        let g_yx = Crypto::p256_ecdh(&y, &g_x);
 
         assert_eq!(g_xy, g_yx);
     }

--- a/examples/edhoc-rs-no_std/src/main.rs
+++ b/examples/edhoc-rs-no_std/src/main.rs
@@ -13,7 +13,7 @@ use panic_semihosting as _;
 #[cfg(feature = "rtt")]
 use rtt_target::{rprintln as println, rtt_init_print};
 
-use edhoc_crypto::{Crypto, CryptoTrait};
+use edhoc_crypto::{default_crypto, CryptoTrait};
 use edhoc_rs::*;
 
 extern crate alloc;
@@ -81,11 +81,11 @@ fn main() -> ! {
     println!("Test test_new_initiator passed.");
 
     fn test_p256_keys() {
-        let (x, g_x) = Crypto::p256_generate_key_pair();
-        let (y, g_y) = Crypto::p256_generate_key_pair();
+        let (x, g_x) = default_crypto().p256_generate_key_pair();
+        let (y, g_y) = default_crypto().p256_generate_key_pair();
 
-        let g_xy = Crypto::p256_ecdh(&x, &g_y);
-        let g_yx = Crypto::p256_ecdh(&y, &g_x);
+        let g_xy = default_crypto().p256_ecdh(&x, &g_y);
+        let g_yx = default_crypto().p256_ecdh(&y, &g_x);
 
         assert_eq!(g_xy, g_yx);
     }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,6 +12,7 @@ hex = { version = "0.4.3", default-features = false }
 
 hacspec-lib = { version = "0.1.0-beta.1", default-features = false, optional = true }
 edhoc-crypto = { path = "../crypto", default-features = false }
+edhoc-crypto-trait = { path = "../crypto/edhoc-crypto-trait" }
 edhoc-consts = { path = "../consts" }
 edhoc-ead = { path = "../ead", default-features = false }
 panic-semihosting = { version = "0.6.0", features = ["exit"], optional = true }

--- a/lib/src/c_wrapper.rs
+++ b/lib/src/c_wrapper.rs
@@ -3,7 +3,7 @@ use core::{slice, str};
 use edhoc_consts::*;
 use hexlit::hex;
 
-use edhoc_crypto::{Crypto, CryptoTrait};
+use edhoc_crypto::{default_crypto, CryptoTrait};
 
 // Panic handler for cortex-m targets
 #[cfg(any(feature = "crypto-cryptocell310", feature = "crypto-psa-baremetal"))]
@@ -12,7 +12,7 @@ use panic_semihosting as _;
 // This function is mainly used to test the C wrapper
 #[no_mangle]
 pub extern "C" fn p256_generate_key_pair_from_c(out_private_key: *mut u8, out_public_key: *mut u8) {
-    let (private_key, public_key) = Crypto::p256_generate_key_pair();
+    let (private_key, public_key) = default_crypto().p256_generate_key_pair();
 
     unsafe {
         // copy the arrays to the pointers received from C

--- a/lib/src/c_wrapper.rs
+++ b/lib/src/c_wrapper.rs
@@ -3,6 +3,8 @@ use core::{slice, str};
 use edhoc_consts::*;
 use hexlit::hex;
 
+use edhoc_crypto::{Crypto, CryptoTrait};
+
 // Panic handler for cortex-m targets
 #[cfg(any(feature = "crypto-cryptocell310", feature = "crypto-psa-baremetal"))]
 use panic_semihosting as _;
@@ -10,7 +12,7 @@ use panic_semihosting as _;
 // This function is mainly used to test the C wrapper
 #[no_mangle]
 pub extern "C" fn p256_generate_key_pair_from_c(out_private_key: *mut u8, out_public_key: *mut u8) {
-    let (private_key, public_key) = edhoc_crypto::p256_generate_key_pair();
+    let (private_key, public_key) = Crypto::p256_generate_key_pair();
 
     unsafe {
         // copy the arrays to the pointers received from C

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -220,7 +220,8 @@ pub fn r_prepare_message_2<Crypto: CryptoTrait>(
         ct.len = plaintext_2.len;
         ct.content[..ct.len].copy_from_slice(&plaintext_2.content[..ct.len]);
 
-        let (ciphertext_2, ciphertext_2_len) = encrypt_decrypt_ciphertext_2::<Crypto>(&prk_2e, &th_2, &ct);
+        let (ciphertext_2, ciphertext_2_len) =
+            encrypt_decrypt_ciphertext_2::<Crypto>(&prk_2e, &th_2, &ct);
 
         ct.content[..ct.len].copy_from_slice(&ciphertext_2[..ct.len]);
 
@@ -299,8 +300,12 @@ pub fn r_process_message_3<Crypto: CryptoTrait>(
                         prk_4e3m = compute_prk_4e3m::<Crypto>(&salt_4e3m, &y, g_i);
 
                         // compute mac_3
-                        let expected_mac_3 =
-                            compute_mac_3::<Crypto>(&prk_4e3m, &th_3, id_cred_i_expected, cred_i_expected);
+                        let expected_mac_3 = compute_mac_3::<Crypto>(
+                            &prk_4e3m,
+                            &th_3,
+                            id_cred_i_expected,
+                            cred_i_expected,
+                        );
 
                         // verify mac_3
                         if mac_3 == expected_mac_3 {
@@ -311,8 +316,13 @@ pub fn r_process_message_3<Crypto: CryptoTrait>(
                             th_4_buf[..th_4.len()].copy_from_slice(&th_4[..]);
                             // compute prk_out
                             // PRK_out = EDHOC-KDF( PRK_4e3m, 7, TH_4, hash_length )
-                            let prk_out_buf =
-                                edhoc_kdf::<Crypto>(&prk_4e3m, 7u8, &th_4_buf, th_4.len(), SHA256_DIGEST_LEN);
+                            let prk_out_buf = edhoc_kdf::<Crypto>(
+                                &prk_4e3m,
+                                7u8,
+                                &th_4_buf,
+                                th_4.len(),
+                                SHA256_DIGEST_LEN,
+                            );
                             prk_out[..SHA256_DIGEST_LEN]
                                 .copy_from_slice(&prk_out_buf[..SHA256_DIGEST_LEN]);
 
@@ -498,8 +508,12 @@ pub fn i_process_message_2<Crypto: CryptoTrait>(
 
                     prk_3e2m = compute_prk_3e2m::<Crypto>(&salt_3e2m, &x, g_r);
 
-                    let expected_mac_2 =
-                        compute_mac_2::<Crypto>(&prk_3e2m, id_cred_r_expected, cred_r_expected, &th_2);
+                    let expected_mac_2 = compute_mac_2::<Crypto>(
+                        &prk_3e2m,
+                        id_cred_r_expected,
+                        cred_r_expected,
+                        &th_2,
+                    );
 
                     if mac_2 == expected_mac_2 {
                         if kid == id_cred_r_expected[id_cred_r_expected.len() - 1] {
@@ -593,7 +607,8 @@ pub fn i_prepare_message_3<Crypto: CryptoTrait>(
 
         // compute prk_out
         // PRK_out = EDHOC-KDF( PRK_4e3m, 7, TH_4, hash_length )
-        let prk_out_buf = edhoc_kdf::<Crypto>(&prk_4e3m, 7u8, &th_4_buf, th_4.len(), SHA256_DIGEST_LEN);
+        let prk_out_buf =
+            edhoc_kdf::<Crypto>(&prk_4e3m, 7u8, &th_4_buf, th_4.len(), SHA256_DIGEST_LEN);
         prk_out[..SHA256_DIGEST_LEN].copy_from_slice(&prk_out_buf[..SHA256_DIGEST_LEN]);
 
         // compute prk_exporter from prk_out
@@ -992,7 +1007,10 @@ fn encode_message_2(g_y: &BytesP256ElemLen, ciphertext_2: &BufferCiphertext2) ->
     output
 }
 
-fn compute_th_2<Crypto: CryptoTrait>(g_y: &BytesP256ElemLen, h_message_1: &BytesHashLen) -> BytesHashLen {
+fn compute_th_2<Crypto: CryptoTrait>(
+    g_y: &BytesP256ElemLen,
+    h_message_1: &BytesHashLen,
+) -> BytesHashLen {
     let mut message: BytesMaxBuffer = [0x00; MAX_BUFFER_LEN];
     message[0] = CBOR_BYTE_STRING;
     message[1] = P256_ELEM_LEN as u8;
@@ -1307,7 +1325,8 @@ fn compute_mac_2<Crypto: CryptoTrait>(
     // MAC_2 = EDHOC-KDF( PRK_3e2m, 2, context_2, mac_length_2 )
     let mut mac_2: BytesMac2 = [0x00; MAC_LENGTH_2];
     mac_2[..].copy_from_slice(
-        &edhoc_kdf::<Crypto>(prk_3e2m, 2 as u8, &context, context_len, MAC_LENGTH_2)[..MAC_LENGTH_2],
+        &edhoc_kdf::<Crypto>(prk_3e2m, 2 as u8, &context, context_len, MAC_LENGTH_2)
+            [..MAC_LENGTH_2],
     );
 
     mac_2
@@ -1413,10 +1432,14 @@ fn encrypt_decrypt_ciphertext_2<Crypto: CryptoTrait>(
     (plaintext_2, ciphertext_2.len)
 }
 
-fn compute_salt_4e3m<Crypto: CryptoTrait>(prk_3e2m: &BytesHashLen, th_3: &BytesHashLen) -> BytesHashLen {
+fn compute_salt_4e3m<Crypto: CryptoTrait>(
+    prk_3e2m: &BytesHashLen,
+    th_3: &BytesHashLen,
+) -> BytesHashLen {
     let mut th_3_context: BytesMaxContextBuffer = [0x00; MAX_KDF_CONTEXT_LEN];
     th_3_context[..th_3.len()].copy_from_slice(&th_3[..]);
-    let salt_4e3m_buf = edhoc_kdf::<Crypto>(prk_3e2m, 5u8, &th_3_context, th_3.len(), SHA256_DIGEST_LEN);
+    let salt_4e3m_buf =
+        edhoc_kdf::<Crypto>(prk_3e2m, 5u8, &th_3_context, th_3.len(), SHA256_DIGEST_LEN);
     let mut salt_4e3m: BytesHashLen = [0x00; SHA256_DIGEST_LEN];
     salt_4e3m[..].copy_from_slice(&salt_4e3m_buf[..SHA256_DIGEST_LEN]);
 
@@ -1435,7 +1458,10 @@ fn compute_prk_4e3m<Crypto: CryptoTrait>(
     prk_4e3m
 }
 
-fn compute_salt_3e2m<Crypto: CryptoTrait>(prk_2e: &BytesHashLen, th_2: &BytesHashLen) -> BytesHashLen {
+fn compute_salt_3e2m<Crypto: CryptoTrait>(
+    prk_2e: &BytesHashLen,
+    th_2: &BytesHashLen,
+) -> BytesHashLen {
     let mut th_2_context: BytesMaxContextBuffer = [0x00; MAX_KDF_CONTEXT_LEN];
     th_2_context[..th_2.len()].copy_from_slice(&th_2[..]);
 
@@ -1756,7 +1782,8 @@ mod tests {
         th_2_context_tv[..TH_2_TV.len()].copy_from_slice(&TH_2_TV[..]);
         const LEN_TV: usize = PLAINTEXT_2_LEN_TV;
 
-        let output = edhoc_kdf::<Crypto>(&PRK_2E_TV, 0u8, &th_2_context_tv, SHA256_DIGEST_LEN, LEN_TV);
+        let output =
+            edhoc_kdf::<Crypto>(&PRK_2E_TV, 0u8, &th_2_context_tv, SHA256_DIGEST_LEN, LEN_TV);
         for i in 0..KEYSTREAM_2_TV.len() {
             assert_eq!(KEYSTREAM_2_TV[i], output[i]);
         }

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use edhoc_consts::*;
-use edhoc_crypto::*;
+use edhoc_crypto::{Crypto, CryptoTrait};
 use edhoc_ead::*;
 
 pub fn edhoc_exporter(

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -152,7 +152,14 @@ impl<'a> EdhocResponderState<'a> {
         let mut context_buf: BytesMaxContextBuffer = [0x00u8; MAX_KDF_CONTEXT_LEN];
         context_buf[..context.len()].copy_from_slice(context);
 
-        match edhoc_exporter(self.state, &mut default_crypto(), label, &context_buf, context.len(), length) {
+        match edhoc_exporter(
+            self.state,
+            &mut default_crypto(),
+            label,
+            &context_buf,
+            context.len(),
+            length,
+        ) {
             Ok((state, output)) => {
                 self.state = state;
                 Ok(output)
@@ -168,7 +175,12 @@ impl<'a> EdhocResponderState<'a> {
         let mut context_buf = [0x00u8; MAX_KDF_CONTEXT_LEN];
         context_buf[..context.len()].copy_from_slice(context);
 
-        match edhoc_key_update(self.state, &mut default_crypto(), &context_buf, context.len()) {
+        match edhoc_key_update(
+            self.state,
+            &mut default_crypto(),
+            &context_buf,
+            context.len(),
+        ) {
             Ok((state, prk_out_new)) => {
                 self.state = state;
                 Ok(prk_out_new)
@@ -292,7 +304,14 @@ impl<'a> EdhocInitiatorState<'a> {
         let mut context_buf: BytesMaxContextBuffer = [0x00u8; MAX_KDF_CONTEXT_LEN];
         context_buf[..context.len()].copy_from_slice(context);
 
-        match edhoc_exporter(self.state, &mut default_crypto(), label, &context_buf, context.len(), length) {
+        match edhoc_exporter(
+            self.state,
+            &mut default_crypto(),
+            label,
+            &context_buf,
+            context.len(),
+            length,
+        ) {
             Ok((state, output)) => {
                 self.state = state;
                 Ok(output)
@@ -308,7 +327,12 @@ impl<'a> EdhocInitiatorState<'a> {
         let mut context_buf = [0x00u8; MAX_KDF_CONTEXT_LEN];
         context_buf[..context.len()].copy_from_slice(context);
 
-        match edhoc_key_update(self.state, &mut default_crypto(), &context_buf, context.len()) {
+        match edhoc_key_update(
+            self.state,
+            &mut default_crypto(),
+            &context_buf,
+            context.len(),
+        ) {
             Ok((state, prk_out_new)) => {
                 self.state = state;
                 Ok(prk_out_new)

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -87,7 +87,7 @@ impl<'a> EdhocResponderState<'a> {
         self: &mut EdhocResponderState<'a>,
         message_1: &BufferMessage1,
     ) -> Result<(), EDHOCError> {
-        let state = r_process_message_1(self.state, message_1)?;
+        let state = r_process_message_1::<Crypto>(self.state, message_1)?;
         self.state = state;
 
         Ok(())
@@ -99,7 +99,7 @@ impl<'a> EdhocResponderState<'a> {
     ) -> Result<BufferMessage2, EDHOCError> {
         let (y, g_y) = Crypto::p256_generate_key_pair();
 
-        match r_prepare_message_2(
+        match r_prepare_message_2::<Crypto>(
             self.state,
             &self
                 .id_cred_r
@@ -123,7 +123,7 @@ impl<'a> EdhocResponderState<'a> {
         self: &mut EdhocResponderState<'a>,
         message_3: &BufferMessage3,
     ) -> Result<[u8; SHA256_DIGEST_LEN], EDHOCError> {
-        match r_process_message_3(
+        match r_process_message_3::<Crypto>(
             self.state,
             message_3,
             &self
@@ -150,7 +150,7 @@ impl<'a> EdhocResponderState<'a> {
         let mut context_buf: BytesMaxContextBuffer = [0x00u8; MAX_KDF_CONTEXT_LEN];
         context_buf[..context.len()].copy_from_slice(context);
 
-        match edhoc_exporter(self.state, label, &context_buf, context.len(), length) {
+        match edhoc_exporter::<Crypto>(self.state, label, &context_buf, context.len(), length) {
             Ok((state, output)) => {
                 self.state = state;
                 Ok(output)
@@ -166,7 +166,7 @@ impl<'a> EdhocResponderState<'a> {
         let mut context_buf = [0x00u8; MAX_KDF_CONTEXT_LEN];
         context_buf[..context.len()].copy_from_slice(context);
 
-        match edhoc_key_update(self.state, &context_buf, context.len()) {
+        match edhoc_key_update::<Crypto>(self.state, &context_buf, context.len()) {
             Ok((state, prk_out_new)) => {
                 self.state = state;
                 Ok(prk_out_new)
@@ -226,7 +226,7 @@ impl<'a> EdhocInitiatorState<'a> {
     ) -> Result<BufferMessage1, EDHOCError> {
         let (x, g_x) = Crypto::p256_generate_key_pair();
 
-        match i_prepare_message_1(self.state, x, g_x, c_i) {
+        match i_prepare_message_1::<Crypto>(self.state, x, g_x, c_i) {
             Ok((state, message_1)) => {
                 self.state = state;
                 Ok(message_1)
@@ -239,7 +239,7 @@ impl<'a> EdhocInitiatorState<'a> {
         self: &mut EdhocInitiatorState<'a>,
         message_2: &BufferMessage2,
     ) -> Result<u8, EDHOCError> {
-        match i_process_message_2(
+        match i_process_message_2::<Crypto>(
             self.state,
             message_2,
             &self
@@ -263,7 +263,7 @@ impl<'a> EdhocInitiatorState<'a> {
     pub fn prepare_message_3(
         self: &mut EdhocInitiatorState<'a>,
     ) -> Result<(BufferMessage3, [u8; SHA256_DIGEST_LEN]), EDHOCError> {
-        match i_prepare_message_3(
+        match i_prepare_message_3::<Crypto>(
             self.state,
             &self
                 .id_cred_i
@@ -288,7 +288,7 @@ impl<'a> EdhocInitiatorState<'a> {
         let mut context_buf: BytesMaxContextBuffer = [0x00u8; MAX_KDF_CONTEXT_LEN];
         context_buf[..context.len()].copy_from_slice(context);
 
-        match edhoc_exporter(self.state, label, &context_buf, context.len(), length) {
+        match edhoc_exporter::<Crypto>(self.state, label, &context_buf, context.len(), length) {
             Ok((state, output)) => {
                 self.state = state;
                 Ok(output)
@@ -304,7 +304,7 @@ impl<'a> EdhocInitiatorState<'a> {
         let mut context_buf = [0x00u8; MAX_KDF_CONTEXT_LEN];
         context_buf[..context.len()].copy_from_slice(context);
 
-        match edhoc_key_update(self.state, &context_buf, context.len()) {
+        match edhoc_key_update::<Crypto>(self.state, &context_buf, context.len()) {
             Ok((state, prk_out_new)) => {
                 self.state = state;
                 Ok(prk_out_new)

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,8 +1,9 @@
 #![cfg_attr(not(test), no_std)]
 
 pub use {
-    edhoc_consts::State as EdhocState, edhoc_consts::*, edhoc_crypto::*,
-    EdhocInitiatorState as EdhocInitiator, EdhocResponderState as EdhocResponder,
+    edhoc_consts::State as EdhocState, edhoc_consts::*, edhoc_crypto::Crypto,
+    edhoc_crypto::CryptoTrait, EdhocInitiatorState as EdhocInitiator,
+    EdhocResponderState as EdhocResponder,
 };
 
 #[cfg(any(feature = "ead-none", feature = "ead-zeroconf"))]
@@ -96,7 +97,7 @@ impl<'a> EdhocResponderState<'a> {
         self: &mut EdhocResponderState<'a>,
         c_r: u8,
     ) -> Result<BufferMessage2, EDHOCError> {
-        let (y, g_y) = edhoc_crypto::p256_generate_key_pair();
+        let (y, g_y) = Crypto::p256_generate_key_pair();
 
         match r_prepare_message_2(
             self.state,
@@ -223,7 +224,7 @@ impl<'a> EdhocInitiatorState<'a> {
         self: &mut EdhocInitiatorState<'a>,
         c_i: u8,
     ) -> Result<BufferMessage1, EDHOCError> {
-        let (x, g_x) = edhoc_crypto::p256_generate_key_pair();
+        let (x, g_x) = Crypto::p256_generate_key_pair();
 
         match i_prepare_message_1(self.state, x, g_x, c_i) {
             Ok((state, message_1)) => {
@@ -327,9 +328,9 @@ pub fn generate_connection_identifier_cbor() -> u8 {
 
 /// generates an identifier that can be serialized as a single CBOR integer, i.e. -24 <= x <= 23
 pub fn generate_connection_identifier() -> i8 {
-    let mut conn_id = edhoc_crypto::get_random_byte() as i8;
+    let mut conn_id = Crypto::get_random_byte() as i8;
     while conn_id < -24 || conn_id > 23 {
-        conn_id = edhoc_crypto::get_random_byte() as i8;
+        conn_id = Crypto::get_random_byte() as i8;
     }
     conn_id
 }


### PR DESCRIPTION
In this PR I'm experimenting with making the edhoc-crypto module not re-export items from different crates (whose interface is implicitly defined by the shared pub items), but define a type (ideally as `impl Trait`, but until TAIT is stable, as public reexports) that is accessed through a defined trait interface.

Apart from cleaner separation of responsibilities, the longer goal here is to remove the need for one central and depending-on-everyone-depending-on-cfg edhoc-crypto crate, and to replace it with generics on the public structs and functions. While that could be used to run different back-ends in parallel (not sure why one would want that), its main goal is to sever the dependency from the library to the back-ends, making the library both easier to maintain and easier to upload to crates.io (#98). It'd then be up to the application to select its back-end, and propagate that through any intermediate crates that build on edhoc (which now don't have to pass on features any more, but can pass on types, which is also easier to maintain).

The first commit (after the ones from #102 that restore CI) only does this for hacspec -- this was tested locally, and I'm relying on CI to tell me where else changes are needed (while I'm still getting my bearings around the library).