### PR TITLE
Allow applications to pick their C_x

### DIFF
--- a/examples/coap/src/bin/coapclient.rs
+++ b/examples/coap/src/bin/coapclient.rs
@@ -23,7 +23,8 @@ fn main() {
 
     // Send Message 1 over CoAP and convert the response to byte
     let mut msg_1_buf = Vec::from([0xf5u8]); // EDHOC message_1 when transported over CoAP is prepended with CBOR true
-    let message_1 = initiator.prepare_message_1().unwrap();
+    let c_i = generate_connection_identifier_cbor();
+    let message_1 = initiator.prepare_message_1(c_i).unwrap();
     msg_1_buf.extend_from_slice(&message_1.content[..message_1.len]);
     println!("message_1 len = {}", msg_1_buf.len());
 

--- a/examples/coap/src/bin/coapserver.rs
+++ b/examples/coap/src/bin/coapserver.rs
@@ -40,7 +40,8 @@ fn main() {
                 );
 
                 if error.is_ok() {
-                    let (message_2, c_r) = responder.prepare_message_2().unwrap();
+                    let c_r = generate_connection_identifier_cbor();
+                    let message_2 = responder.prepare_message_2(c_r).unwrap();
                     response.message.payload = Vec::from(&message_2.content[..message_2.len]);
                     // save edhoc connection
                     edhoc_connections.push((c_r, responder));

--- a/examples/edhoc-rs-no_std/src/main.rs
+++ b/examples/edhoc-rs-no_std/src/main.rs
@@ -99,7 +99,8 @@ fn main() -> ! {
         let mut initiator =
             EdhocInitiator::new(state, I, G_R, ID_CRED_I, CRED_I, ID_CRED_R, CRED_R);
 
-        let message_1 = initiator.prepare_message_1();
+        let c_i: u8 = generate_connection_identifier_cbor().into();
+        let message_1 = initiator.prepare_message_1(c_i);
         assert!(message_1.is_ok());
     }
 
@@ -128,16 +129,18 @@ fn main() -> ! {
             CRED_R,
         );
 
-        let ret = initiator.prepare_message_1(); // to update the state
+        let c_i: u8 = generate_connection_identifier_cbor().into();
+        let ret = initiator.prepare_message_1(c_i); // to update the state
         assert!(ret.is_ok());
         let message_1 = ret.unwrap();
 
         let ret = responder.process_message_1(&message_1);
         assert!(ret.is_ok());
 
-        let ret = responder.prepare_message_2();
+        let c_r: u8 = generate_connection_identifier_cbor().into();
+        let ret = responder.prepare_message_2(c_r);
         assert!(ret.is_ok());
-        let (message_2, c_r) = ret.unwrap();
+        let message_2 = ret.unwrap();
         assert!(c_r != 0xff);
 
         let _c_r = initiator.process_message_2(&message_2);

--- a/lib/src/c_wrapper.rs
+++ b/lib/src/c_wrapper.rs
@@ -158,7 +158,8 @@ pub unsafe extern "C" fn initiator_prepare_message_1(
 ) -> i8 {
     let mut initiator = (*initiator_c).to_rust();
 
-    let result = match initiator.prepare_message_1() {
+    let c_i: u8 = generate_connection_identifier_cbor().into();
+    let result = match initiator.prepare_message_1(c_i) {
         Ok(msg_1) => {
             *message_1 = msg_1;
             0
@@ -196,10 +197,11 @@ pub unsafe extern "C" fn responder_prepare_message_2(
 ) -> i8 {
     let mut responder = (*responder_c).to_rust();
 
-    let result = match responder.prepare_message_2() {
-        Ok((msg_2, c_r_res)) => {
+    let c_r_chosen: u8 = generate_connection_identifier_cbor().into();
+    let result = match responder.prepare_message_2(c_r_chosen) {
+        Ok(msg_2) => {
             *message_2 = msg_2;
-            *c_r = c_r_res;
+            *c_r = c_r_chosen;
             0
         }
         Err(err) => err as i8,

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -179,7 +179,7 @@ pub fn r_prepare_message_2(
     y: BytesP256ElemLen,
     g_y: BytesP256ElemLen,
     c_r: u8,
-) -> Result<(State, BufferMessage2, u8), EDHOCError> {
+) -> Result<(State, BufferMessage2), EDHOCError> {
     let State(
         mut current_state,
         mut _y,
@@ -247,7 +247,7 @@ pub fn r_prepare_message_2(
     }
 
     match error {
-        EDHOCError::Success => Ok((state, message_2, c_r)),
+        EDHOCError::Success => Ok((state, message_2)),
         _ => Err(error),
     }
 }


### PR DESCRIPTION
Applications may need to pick their own C_x (as opposed to the EDHOC library picking one at random, as it was before) for three reasons:

* The library doesn't manage the set of contexts, so it can't know which C_x are already in use and which are not.
* The C_x may be used for other purposes (eg. OSCORE contexts), and might be namespaced there, which also only the application may know. (Silly example, but the application may use the OSCORE context identifiers that correspond to negative C_x for use with ACE-OSCORE profile, and only those with positive C_x for EDHOC).
* When processing of message 1 and creation of message 2 are split over time (as is necessary when implementing an EDHOC server on the coap-handler interface), it is practical to already decide on a C_R at processing time, store the responder, and dig it up when creating the response -- but that requires the C_R to be decided already at storing time.

This will likely need follow-ups for similarly delegating the choice of {ID_,}CRED_peer to the callers (resolving #99 issues from), but those are separate enough that I'd do them in a separate PR.

These are API breaking changes. They're split in two because I did C_R first, and kept them split to ease review especially on the CI side; when ACK'ed, I'd like to squash them.