### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# To use this hook:
+# brew (or pip) install pre-commit
+# pre-commit install
+
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+files: '^.*(.*\.rs|README.md)$'
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt


### PR DESCRIPTION
This will not affect the development workflow unless opted-in with:

- brew (or pip) install pre-commit
- pre-commit install

The benefit is no more CI failing due to missing `cargo fmt` runs :) 