### PR TITLE
Add default features to edhoc-rs-no_std example and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,17 @@ To build an example application that works on the [nrf52840dk](https://www.nordi
 # head to the example `no_std` example
 cd ./examples/edhoc-rs-no_std
 
-# build using the psa crypto backend (software-based)
-cargo build --target="thumbv7em-none-eabihf" --no-default-features --features="crypto-psa, rtt" --release
-
 # build using the cryptocell310 crypto backend (hardware-accelerated)
-cargo build --target="thumbv7em-none-eabihf" --no-default-features --features="crypto-cryptocell310, rtt"
+cargo build --target="thumbv7em-none-eabihf" --release
+
+# build using the psa crypto backend (software-based)
+cargo build --target="thumbv7em-none-eabihf" --no-default-features --features="crypto-psa, ead-none, rtt" --release
+
 ```
 
 To build **and** flash to the board, replace the word `build` with `embed` in the commands above (you may need to `cargo install cargo-embed`).
 
-For example: `cargo embed --target="thumbv7em-none-eabihf" --no-default-features --features="cryptocell310, rtt"`
+For example: `cargo embed --target="thumbv7em-none-eabihf" --no-default-features --features="crypto-psa, ead-none, rtt"`
 
 ## Directory structure
 This library is structured as a Workspace, a feature from Cargo which makes it easy to manage more than one package / application in the same repository. Here are its the main folders:

--- a/examples/edhoc-rs-no_std/Cargo.toml
+++ b/examples/edhoc-rs-no_std/Cargo.toml
@@ -20,7 +20,7 @@ panic-semihosting = { version = "0.6.0", features = ["exit"] }
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 
 [features]
-default = [ ]
+default = [ "rtt", "crypto-cryptocell310", "ead-none" ]
 rtt = [ ]
 crypto-psa = [ "edhoc-rs/crypto-psa-baremetal" ]
 crypto-cryptocell310 = [ "edhoc-rs/crypto-cryptocell310" ]


### PR DESCRIPTION
Just did a quick test on building with PSA and cryptocell on nrf52840-dk. README.md was a little outdated. I also updated the default features of the example to use cryptocell310 backend.