### PR TITLE
Refactor process_message_3 to follow implementation guidelines

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,7 +66,7 @@ jobs:
     needs: unit-tests
     runs-on: ubuntu-latest
     if: >-
-      vars.SHOULD_GENERATE_FSTAR == 1 &&
+      ${{ vars.SHOULD_GENERATE_FSTAR == ‘true’ }} &&
       ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')))
 
     steps:

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -99,7 +99,7 @@ impl<'a> EdhocResponderState<'a> {
         self: &mut EdhocResponderState<'a>,
         message_3: &BufferMessage3,
     ) -> Result<[u8; SHA256_DIGEST_LEN], EDHOCError> {
-        match r_process_message_3(self.state, message_3, self.cred_i.unwrap()) {
+        match r_process_message_3(self.state, message_3, self.cred_i) {
             Ok((state, prk_out)) => {
                 self.state = state;
                 Ok(prk_out)


### PR DESCRIPTION
This PR updates `r_process_message_3` routine to allow generic handling of EAD items and of credentials, as per draft-tiloca-lake-implem-cons. 

It also updated the `decode_plaintext_3` routine to enable the credential to be passed in the message by value, instead only by reference.

Closes #129 