### PR TITLE
Safe access to buffer via `.get(index)?`

### DIFF
--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -160,6 +160,7 @@ pub enum AccessError {
 
 impl From<AccessError> for EDHOCError {
     fn from(error: AccessError) -> Self {
+        // TODO: can we make this conversion more robust, i.e. what if the access fails but the reason is not ParsingError?
         match error {
             AccessError::OutOfBounds => EDHOCError::ParsingError,
         }

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -895,8 +895,7 @@ fn decode_plaintext_3(
     if res.is_ok() {
         let (mut offset, id_cred_i) = res.unwrap();
 
-        if (is_cbor_bstr_1byte_prefix(plaintext_3.content[1])) {
-            // FIXME[urgent]: should access [offset] instead of [1]
+        if (is_cbor_bstr_1byte_prefix(plaintext_3.get(offset)?)) {
             // skip the CBOR magic byte as we know how long the MAC is
             offset += 1;
             mac_3[..].copy_from_slice(&plaintext_3.get_slice(offset, offset + MAC_LENGTH_3)?);

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -870,25 +870,22 @@ fn edhoc_kdf(
 fn decode_plaintext_3(
     plaintext_3: &BufferPlaintext3,
 ) -> Result<(IdCred, BytesMac3, Option<EADItem>), EDHOCError> {
-    let kid: u8;
     let mut mac_3: BytesMac3 = [0x00; MAC_LENGTH_3];
     let id_cred_i: IdCred;
+    let first_byte = plaintext_3.get(0)?;
 
     // check ID_CRED_I and MAC_3
-    let res = if (is_cbor_neg_int_1byte(plaintext_3.content[0])
-        || is_cbor_uint_1byte(plaintext_3.content[0]))
-    {
+    let res = if (is_cbor_neg_int_1byte(first_byte) || is_cbor_uint_1byte(first_byte)) {
         // KID
-        kid = plaintext_3.content[0usize];
-        let id_cred_i = IdCred::CompactKid(plaintext_3.content[0usize]);
+        let id_cred_i = IdCred::CompactKid(first_byte);
         Ok((1, id_cred_i))
-    } else if is_cbor_bstr_2bytes_prefix(plaintext_3.content[0])
-        && is_cbor_uint_2bytes(plaintext_3.content[1])
-        && (plaintext_3.content[2] as usize) < plaintext_3.len
+    } else if is_cbor_bstr_2bytes_prefix(first_byte)
+        && is_cbor_uint_2bytes(plaintext_3.get(1)?)
+        && (plaintext_3.get(2)? as usize) < plaintext_3.len
     {
         // full credential
-        let cred_len = plaintext_3.content[2] as usize;
-        id_cred_i = IdCred::FullCredential(&plaintext_3.content[3..3 + cred_len]);
+        let cred_len = plaintext_3.get(2)? as usize;
+        id_cred_i = IdCred::FullCredential(&plaintext_3.get_slice(3, 3 + cred_len)?);
         Ok((3 + cred_len, id_cred_i))
     } else {
         // error
@@ -899,9 +896,10 @@ fn decode_plaintext_3(
         let (mut offset, id_cred_i) = res.unwrap();
 
         if (is_cbor_bstr_1byte_prefix(plaintext_3.content[1])) {
+            // FIXME[urgent]: should access [offset] instead of [1]
             // skip the CBOR magic byte as we know how long the MAC is
             offset += 1;
-            mac_3[..].copy_from_slice(&plaintext_3.content[offset..offset + MAC_LENGTH_3]);
+            mac_3[..].copy_from_slice(&plaintext_3.get_slice(offset, offset + MAC_LENGTH_3)?);
 
             // if there is still more to parse, the rest will be the EAD_3
             if plaintext_3.len > (offset + MAC_LENGTH_3) {

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -761,14 +761,14 @@ fn parse_message_2(
     let mut ciphertext_2: BufferCiphertext2 = BufferCiphertext2::new();
 
     // ensure the whole message is a single CBOR sequence
-    if is_cbor_bstr_2bytes_prefix(rcvd_message_2.content[0])
-        && rcvd_message_2.content[1] == (rcvd_message_2.len as u8 - 2)
+    if is_cbor_bstr_2bytes_prefix(rcvd_message_2.get(0)?)
+        && rcvd_message_2.get(1)? == (rcvd_message_2.len as u8 - 2)
     {
-        g_y[..].copy_from_slice(&rcvd_message_2.content[2..2 + P256_ELEM_LEN]);
+        g_y[..].copy_from_slice(rcvd_message_2.get_slice(2, 2 + P256_ELEM_LEN)?);
 
         ciphertext_2.len = rcvd_message_2.len - P256_ELEM_LEN - 2; // len - gy_len - 2
         ciphertext_2.content[..ciphertext_2.len].copy_from_slice(
-            &rcvd_message_2.content[2 + P256_ELEM_LEN..2 + P256_ELEM_LEN + ciphertext_2.len],
+            rcvd_message_2.get_slice(2 + P256_ELEM_LEN, 2 + P256_ELEM_LEN + ciphertext_2.len)?,
         );
 
         Ok((g_y, ciphertext_2))


### PR DESCRIPTION
@malishav as discussed, this is a proposal for safely accessing the received buffer. Added a partial implementation to enable a quick first-pass review.