### PR TITLE
Safe cbor parsing

### DIFF
--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -160,6 +160,7 @@ pub enum AccessError {
 
 impl From<AccessError> for EDHOCError {
     fn from(error: AccessError) -> Self {
+        // TODO: can we make this conversion more robust, i.e. what if the access fails but the reason is not ParsingError?
         match error {
             AccessError::OutOfBounds => EDHOCError::ParsingError,
         }

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -895,8 +895,7 @@ fn decode_plaintext_3(
     if res.is_ok() {
         let (mut offset, id_cred_i) = res.unwrap();
 
-        if (is_cbor_bstr_1byte_prefix(plaintext_3.content[1])) {
-            // FIXME[urgent]: should access [offset] instead of [1]
+        if (is_cbor_bstr_1byte_prefix(plaintext_3.get(offset)?)) {
             // skip the CBOR magic byte as we know how long the MAC is
             offset += 1;
             mac_3[..].copy_from_slice(&plaintext_3.get_slice(offset, offset + MAC_LENGTH_3)?);

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -870,25 +870,22 @@ fn edhoc_kdf(
 fn decode_plaintext_3(
     plaintext_3: &BufferPlaintext3,
 ) -> Result<(IdCred, BytesMac3, Option<EADItem>), EDHOCError> {
-    let kid: u8;
     let mut mac_3: BytesMac3 = [0x00; MAC_LENGTH_3];
     let id_cred_i: IdCred;
+    let first_byte = plaintext_3.get(0)?;
 
     // check ID_CRED_I and MAC_3
-    let res = if (is_cbor_neg_int_1byte(plaintext_3.content[0])
-        || is_cbor_uint_1byte(plaintext_3.content[0]))
-    {
+    let res = if (is_cbor_neg_int_1byte(first_byte) || is_cbor_uint_1byte(first_byte)) {
         // KID
-        kid = plaintext_3.content[0usize];
-        let id_cred_i = IdCred::CompactKid(plaintext_3.content[0usize]);
+        let id_cred_i = IdCred::CompactKid(first_byte);
         Ok((1, id_cred_i))
-    } else if is_cbor_bstr_2bytes_prefix(plaintext_3.content[0])
-        && is_cbor_uint_2bytes(plaintext_3.content[1])
-        && (plaintext_3.content[2] as usize) < plaintext_3.len
+    } else if is_cbor_bstr_2bytes_prefix(first_byte)
+        && is_cbor_uint_2bytes(plaintext_3.get(1)?)
+        && (plaintext_3.get(2)? as usize) < plaintext_3.len
     {
         // full credential
-        let cred_len = plaintext_3.content[2] as usize;
-        id_cred_i = IdCred::FullCredential(&plaintext_3.content[3..3 + cred_len]);
+        let cred_len = plaintext_3.get(2)? as usize;
+        id_cred_i = IdCred::FullCredential(&plaintext_3.get_slice(3, 3 + cred_len)?);
         Ok((3 + cred_len, id_cred_i))
     } else {
         // error
@@ -899,9 +896,10 @@ fn decode_plaintext_3(
         let (mut offset, id_cred_i) = res.unwrap();
 
         if (is_cbor_bstr_1byte_prefix(plaintext_3.content[1])) {
+            // FIXME[urgent]: should access [offset] instead of [1]
             // skip the CBOR magic byte as we know how long the MAC is
             offset += 1;
-            mac_3[..].copy_from_slice(&plaintext_3.content[offset..offset + MAC_LENGTH_3]);
+            mac_3[..].copy_from_slice(&plaintext_3.get_slice(offset, offset + MAC_LENGTH_3)?);
 
             // if there is still more to parse, the rest will be the EAD_3
             if plaintext_3.len > (offset + MAC_LENGTH_3) {

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -97,7 +97,7 @@ pub fn r_process_message_1(
     // g_x will be saved to the state
     let res = parse_message_1(message_1);
 
-    if res.is_ok() {
+    if res.is_some() {
         let (method, suites_i, suites_i_len, g_x, c_i, ead_1) = res.unwrap();
         // verify that the method is supported
         if method == EDHOC_METHOD {
@@ -139,7 +139,7 @@ pub fn r_process_message_1(
             Err(EDHOCError::UnsupportedMethod)
         }
     } else {
-        Err(res.unwrap_err())
+        Err(EDHOCError::ParsingError)
     }
 }
 
@@ -1506,7 +1506,7 @@ mod tests {
 
         // first time message_1 parsing
         let res = parse_message_1(&message_1_tv_first_time);
-        assert!(res.is_ok());
+        assert!(res.is_some());
         let (method, suites_i, suites_i_len, g_x, c_i, ead_1) = res.unwrap();
 
         assert_eq!(method, METHOD_TV_FIRST_TIME);
@@ -1517,7 +1517,7 @@ mod tests {
 
         // second time message_1
         let res = parse_message_1(&message_1_tv);
-        assert!(res.is_ok());
+        assert!(res.is_some());
         let (method, suites_i, suites_i_len, g_x, c_i, ead_1) = res.unwrap();
 
         assert_eq!(method, METHOD_TV);
@@ -1530,35 +1530,23 @@ mod tests {
     #[test]
     fn test_parse_message_1_invalid_traces() {
         let message_1_tv = BufferMessage1::from_hex(MESSAGE_1_INVALID_ARRAY_TV);
-        assert_eq!(
-            parse_message_1(&message_1_tv).unwrap_err(),
-            EDHOCError::ParsingError
-        );
+        assert!(parse_message_1(&message_1_tv).is_none(),);
 
         let message_1_tv = BufferMessage1::from_hex(MESSAGE_1_INVALID_C_I_TV);
-        assert_eq!(
-            parse_message_1(&message_1_tv).unwrap_err(),
-            EDHOCError::ParsingError
-        );
+        assert!(parse_message_1(&message_1_tv).is_none(),);
 
         let message_1_tv = BufferMessage1::from_hex(MESSAGE_1_INVALID_CIPHERSUITE_TV);
-        assert_eq!(
-            parse_message_1(&message_1_tv).unwrap_err(),
-            EDHOCError::ParsingError
-        );
+        assert!(parse_message_1(&message_1_tv).is_none(),);
 
         let message_1_tv = BufferMessage1::from_hex(MESSAGE_1_INVALID_TEXT_EPHEMERAL_KEY_TV);
-        assert_eq!(
-            parse_message_1(&message_1_tv).unwrap_err(),
-            EDHOCError::ParsingError
-        );
+        assert!(parse_message_1(&message_1_tv).is_none(),);
     }
 
     #[test]
     fn test_parse_message_2_invalid_traces() {
         let message_2_tv = BufferMessage1::from_hex(MESSAGE_2_INVALID_NUMBER_OF_CBOR_SEQUENCE_TV);
         assert_eq!(
-            parse_message_1(&message_2_tv).unwrap_err(),
+            parse_message_2(&message_2_tv).unwrap_err(),
             EDHOCError::ParsingError
         );
     }
@@ -1894,7 +1882,7 @@ mod tests {
         let ead_value_tv = EdhocMessageBuffer::from_hex(EAD_DUMMY_VALUE_TV);
 
         let res = parse_message_1(&message_1_ead_tv);
-        assert!(res.is_ok());
+        assert!(res.is_some());
         let (_method, _suites_i, _suites_i_len, _g_x, _c_i, ead_1) = res.unwrap();
         let ead_1 = ead_1.unwrap();
         assert!(ead_1.is_critical);

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -753,30 +753,6 @@ fn encode_message_1(
     output
 }
 
-fn parse_message_2(
-    rcvd_message_2: &BufferMessage2,
-) -> Result<(BytesP256ElemLen, BufferCiphertext2), EDHOCError> {
-    // FIXME decode negative integers as well
-    let mut g_y: BytesP256ElemLen = [0x00; P256_ELEM_LEN];
-    let mut ciphertext_2: BufferCiphertext2 = BufferCiphertext2::new();
-
-    // ensure the whole message is a single CBOR sequence
-    if is_cbor_bstr_2bytes_prefix(rcvd_message_2.get(0)?)
-        && rcvd_message_2.get(1)? == (rcvd_message_2.len as u8 - 2)
-    {
-        g_y[..].copy_from_slice(rcvd_message_2.get_slice(2, 2 + P256_ELEM_LEN)?);
-
-        ciphertext_2.len = rcvd_message_2.len - P256_ELEM_LEN - 2; // len - gy_len - 2
-        ciphertext_2.content[..ciphertext_2.len].copy_from_slice(
-            rcvd_message_2.get_slice(2 + P256_ELEM_LEN, 2 + P256_ELEM_LEN + ciphertext_2.len)?,
-        );
-
-        Ok((g_y, ciphertext_2))
-    } else {
-        Err(EDHOCError::ParsingError)
-    }
-}
-
 fn encode_message_2(g_y: &BytesP256ElemLen, ciphertext_2: &BufferCiphertext2) -> BufferMessage2 {
     let mut output: BufferMessage2 = BufferMessage2::new();
 

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -761,14 +761,14 @@ fn parse_message_2(
     let mut ciphertext_2: BufferCiphertext2 = BufferCiphertext2::new();
 
     // ensure the whole message is a single CBOR sequence
-    if is_cbor_bstr_2bytes_prefix(rcvd_message_2.content[0])
-        && rcvd_message_2.content[1] == (rcvd_message_2.len as u8 - 2)
+    if is_cbor_bstr_2bytes_prefix(rcvd_message_2.get(0)?)
+        && rcvd_message_2.get(1)? == (rcvd_message_2.len as u8 - 2)
     {
-        g_y[..].copy_from_slice(&rcvd_message_2.content[2..2 + P256_ELEM_LEN]);
+        g_y[..].copy_from_slice(rcvd_message_2.get_slice(2, 2 + P256_ELEM_LEN)?);
 
         ciphertext_2.len = rcvd_message_2.len - P256_ELEM_LEN - 2; // len - gy_len - 2
         ciphertext_2.content[..ciphertext_2.len].copy_from_slice(
-            &rcvd_message_2.content[2 + P256_ELEM_LEN..2 + P256_ELEM_LEN + ciphertext_2.len],
+            rcvd_message_2.get_slice(2 + P256_ELEM_LEN, 2 + P256_ELEM_LEN + ciphertext_2.len)?,
         );
 
         Ok((g_y, ciphertext_2))


### PR DESCRIPTION
This is an alternative approach to the safe parsing of incoming messages.

It is inspired by the [minicbor](https://gitlab.com/twittner/minicbor) library, and will enable code like this:

```rust
let input = [0x01, 0x20, 0x62, 0x68, 0x69, 0x42, 0xFE, 0xFE];
let mut decoder = CBORDecoder::new(&input);

decoder.u8()?; // 1
decoder.i8()?; // -1
decoder.str()?; // [0x68, 0x69], meaning "hi"
decoder.bytes()?; // [0xFE, 0xFE]
```

Comments:
- Now there are two layers: buffer access and CBOR decoding
  - Buffer access uses the standard `slice.get(index)?` which is safe and returns `Option`. With this we begin to be agnostic of buffer implementation.
  - Buffer access only happen inside CBORDecoder, which translates any invalid (`None`) accesses into `CBORError::DecodingError`
- The `parse_` and `decode_` functions will only interact with the `CBORDecoder`, and will not access the buffer directly.
- Errors can be chained with `?` via `impl From<CBORError> for EDHOCError`.

Finally, I also tried to use `minicbor` directly, but for the snippet above it brings an additional 20 KB of flash usage.