### PR TITLE
[hax] backporting safe cbor parsing (PR #140)

### DIFF
--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
 pub use cbor::*;
-pub use common_edhoc_parsing::*;
+pub use cbor_decoder::*;
+pub use edhoc_parser::*;
 pub use helpers::*;
 
 // ---- constants and types
@@ -144,6 +145,7 @@ impl Default for EdhocMessageBuffer {
 
 pub trait MessageBufferTrait {
     fn new() -> Self;
+    fn as_slice<'a>(&'a self) -> &'a [u8];
     fn from_hex(hex: &str) -> Self;
 }
 
@@ -154,6 +156,11 @@ impl MessageBufferTrait for EdhocMessageBuffer {
             len: 0,
         }
     }
+
+    fn as_slice<'a>(&'a self) -> &'a [u8] {
+        &self.content[0..self.len]
+    }
+
     fn from_hex(hex: &str) -> Self {
         let mut buffer = EdhocMessageBuffer::new();
         buffer.len = hex.len() / 2;
@@ -331,196 +338,6 @@ mod helpers {
     }
 }
 
-mod common_edhoc_parsing {
-    use super::cbor::*;
-    use super::*;
-
-    pub fn parse_suites_i(
-        rcvd_message_1: &BufferMessage1,
-    ) -> Result<(BytesSuites, usize, usize), EDHOCError> {
-        let mut error: EDHOCError = EDHOCError::UnknownError;
-        let mut raw_suites_len = 0;
-        let mut suites_i = [0u8; SUITES_LEN];
-        let mut suites_i_len: usize = 0;
-
-        // match based on first byte of SUITES_I, which can be either an int or an array
-        if is_cbor_uint_1byte(rcvd_message_1.content[1]) {
-            // CBOR unsigned integer (0..=23)
-            suites_i[0] = rcvd_message_1.content[1];
-            suites_i_len = 1;
-            raw_suites_len = 1;
-            error = EDHOCError::Success;
-        } else if is_cbor_uint_2bytes(rcvd_message_1.content[1]) {
-            // CBOR unsigned integer (one-byte uint8_t follows)
-            suites_i[0] = rcvd_message_1.content[2];
-            suites_i_len = 1;
-            raw_suites_len = 2;
-            error = EDHOCError::Success;
-        } else if is_cbor_array_1byte_prefix(rcvd_message_1.content[1]) {
-            // CBOR array (0..=23 data items follow)
-            // the CBOR array length is encoded in the first byte, so we extract it
-            let suites_len: usize = (rcvd_message_1.content[1] - CBOR_MAJOR_ARRAY).into();
-            raw_suites_len = 1; // account for the CBOR_MAJOR_ARRAY byte
-            if suites_len > 1 && suites_len <= EDHOC_SUITES.len() {
-                // cipher suite array must be at least 2 elements long, but not longer than the defined cipher suites
-                let mut error_occurred = false;
-                for j in 0..suites_len {
-                    raw_suites_len += 1;
-                    if !error_occurred {
-                        // parse based on cipher suite identifier
-                        if is_cbor_uint_1byte(rcvd_message_1.content[raw_suites_len]) {
-                            // CBOR unsigned integer (0..23)
-                            suites_i[j] = rcvd_message_1.content[raw_suites_len];
-                            suites_i_len += 1;
-                        } else if is_cbor_uint_2bytes(rcvd_message_1.content[raw_suites_len]) {
-                            // CBOR unsigned integer (one-byte uint8_t follows)
-                            raw_suites_len += 1; // account for the 0x18 tag byte
-                            suites_i[j] = rcvd_message_1.content[raw_suites_len];
-                            suites_i_len += 1;
-                        } else {
-                            error = EDHOCError::ParsingError;
-                            error_occurred = true;
-                        }
-                    }
-                }
-                if !error_occurred {
-                    error = EDHOCError::Success;
-                }
-            } else {
-                error = EDHOCError::ParsingError;
-            }
-        } else {
-            error = EDHOCError::ParsingError;
-        }
-
-        match error {
-            EDHOCError::Success => Ok((suites_i, suites_i_len, raw_suites_len)),
-            _ => Err(error),
-        }
-    }
-
-    pub fn parse_ead(
-        message: &EdhocMessageBuffer,
-        offset: usize,
-    ) -> Result<Option<EADItem>, EDHOCError> {
-        let mut error: EDHOCError = EDHOCError::UnknownError;
-        let mut ead_item = None::<EADItem>;
-        let mut ead_value = None::<EdhocMessageBuffer>;
-
-        // assuming label is a single byte integer (negative or positive)
-        let label = message.content[offset];
-        let res_label = if is_cbor_uint_1byte(label) {
-            // CBOR unsigned integer (0..=23)
-            Ok((label as u8, false))
-        } else if is_cbor_neg_int_1byte(label) {
-            // CBOR negative integer (-1..=-24)
-            Ok((label - (CBOR_NEG_INT_1BYTE_START - 1), true))
-        } else {
-            Err(EDHOCError::ParsingError)
-        };
-
-        if res_label.is_ok() {
-            let (label, is_critical) = res_label.unwrap();
-            if message.len > (offset + 1) {
-                // EAD value is present
-                let mut buffer = EdhocMessageBuffer::new();
-                buffer.content[..message.len - (offset + 1)]
-                    .copy_from_slice(&message.content[offset + 1..message.len]);
-                buffer.len = message.len - (offset + 1);
-                ead_value = Some(buffer);
-            }
-            ead_item = Some(EADItem {
-                label,
-                is_critical,
-                value: ead_value,
-            });
-            error = EDHOCError::Success;
-        } else {
-            error = res_label.unwrap_err();
-        }
-
-        match error {
-            EDHOCError::Success => Ok(ead_item),
-            _ => Err(error),
-        }
-    }
-
-    pub fn parse_message_1(
-        rcvd_message_1: &BufferMessage1,
-    ) -> Result<
-        (
-            u8,
-            BytesSuites,
-            usize,
-            BytesP256ElemLen,
-            u8,
-            Option<EADItem>,
-        ),
-        EDHOCError,
-    > {
-        let mut error: EDHOCError = EDHOCError::UnknownError;
-        let mut method: u8 = 0xff;
-        let mut g_x: BytesP256ElemLen = [0x00; P256_ELEM_LEN];
-        let mut suites_i: BytesSuites = [0u8; SUITES_LEN];
-        let mut suites_i_len: usize = 0;
-        let mut raw_suites_len: usize = 0;
-        let mut c_i = 0;
-        let mut ead_1 = None::<EADItem>;
-
-        // first element of CBOR sequence must be an integer
-        if is_cbor_uint_1byte(rcvd_message_1.content[0]) {
-            method = rcvd_message_1.content[0];
-            let res_suites = parse_suites_i(rcvd_message_1);
-
-            if res_suites.is_ok() {
-                (suites_i, suites_i_len, raw_suites_len) = res_suites.unwrap();
-
-                if is_cbor_bstr_2bytes_prefix(rcvd_message_1.content[1 + raw_suites_len]) {
-                    g_x.copy_from_slice(
-                        &rcvd_message_1.content
-                            [3 + raw_suites_len..3 + raw_suites_len + P256_ELEM_LEN],
-                    );
-
-                    c_i = rcvd_message_1.content[3 + raw_suites_len + P256_ELEM_LEN];
-                    // check that c_i is encoded as single-byte int (we still do not support bstr encoding)
-                    if is_cbor_neg_int_1byte(c_i) || is_cbor_uint_1byte(c_i) {
-                        // if there is still more to parse, the rest will be the EAD_1
-                        if rcvd_message_1.len > (4 + raw_suites_len + P256_ELEM_LEN) {
-                            // NOTE: since the current implementation only supports one EAD handler,
-                            // we assume only one EAD item
-                            let ead_res =
-                                parse_ead(rcvd_message_1, 4 + raw_suites_len + P256_ELEM_LEN);
-                            if ead_res.is_ok() {
-                                ead_1 = ead_res.unwrap();
-                                error = EDHOCError::Success;
-                            } else {
-                                error = ead_res.unwrap_err();
-                            }
-                        } else if rcvd_message_1.len == (4 + raw_suites_len + P256_ELEM_LEN) {
-                            error = EDHOCError::Success;
-                        } else {
-                            error = EDHOCError::ParsingError;
-                        }
-                    } else {
-                        error = EDHOCError::ParsingError;
-                    }
-                } else {
-                    error = EDHOCError::ParsingError;
-                }
-            } else {
-                error = res_suites.unwrap_err();
-            }
-        } else {
-            error = EDHOCError::ParsingError;
-        }
-
-        match error {
-            EDHOCError::Success => Ok((method, suites_i, suites_i_len, g_x, c_i, ead_1)),
-            _ => Err(error),
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::helpers::*;
@@ -538,5 +355,431 @@ mod test {
         assert_eq!(g_a, G_A_TV);
         assert_eq!(kid, ID_CRED_TV[3]);
         assert_eq!(get_id_cred(CRED_TV), ID_CRED_TV);
+    }
+}
+
+// TODO: move to own file (or even to the main crate, once EAD is extracted as an external dependency)
+mod edhoc_parser {
+    use super::*;
+
+    pub fn parse_ead(buffer: &[u8]) -> Result<Option<EADItem>, EDHOCError> {
+        let ead_item;
+        let mut ead_value = None::<EdhocMessageBuffer>;
+
+        // assuming label is a single byte integer (negative or positive)
+        let label = match buffer.get(0) {
+            Some(b) => *b,
+            _ => return Err(EDHOCError::ParsingError),
+        };
+
+        let (label, is_critical) = if CBORDecoder::is_u8(label) {
+            // CBOR unsigned integer (0..=23)
+            (label as u8, false)
+        } else if CBORDecoder::is_i8(label) {
+            // CBOR negative integer (-1..=-24)
+            (label - (CBOR_NEG_INT_1BYTE_START - 1), true)
+        } else {
+            return Err(EDHOCError::ParsingError);
+        };
+
+        if buffer.len() > 1 {
+            // EAD value is present
+            let slice = match buffer.get(1..buffer.len()) {
+                Some(slice) => slice,
+                _ => return Err(EDHOCError::ParsingError),
+            };
+
+            let mut buffer = EdhocMessageBuffer::new();
+            buffer.content[..slice.len()].copy_from_slice(slice);
+            buffer.len = slice.len();
+            ead_value = Some(buffer);
+        }
+        ead_item = Some(EADItem {
+            label,
+            is_critical,
+            value: ead_value,
+        });
+        Ok(ead_item)
+    }
+
+    pub fn parse_suites_i(
+        mut decoder: CBORDecoder,
+    ) -> Result<(BytesSuites, usize, CBORDecoder), EDHOCError> {
+        let mut suites_i: BytesSuites = Default::default();
+        let suites_i_len: usize;
+        if let Ok(curr) = decoder.current() {
+            if CBOR_UINT_1BYTE_START == CBORDecoder::type_of(curr) {
+                suites_i[0] = decoder.u8()?;
+                suites_i_len = 1;
+                Ok((suites_i, suites_i_len, decoder))
+            } else if CBOR_MAJOR_ARRAY == CBORDecoder::type_of(curr)
+                && CBORDecoder::info_of(curr) >= 2
+            {
+                // NOTE: arrays must be at least 2 items long, otherwise the compact encoding (int) must be used
+                suites_i_len = decoder.array()?;
+                if suites_i_len <= suites_i.len() {
+                    for i in 0..suites_i_len {
+                        suites_i[i] = decoder.u8()?;
+                    }
+                    Ok((suites_i, suites_i_len, decoder))
+                } else {
+                    Err(EDHOCError::ParsingError)
+                }
+            } else {
+                Err(EDHOCError::ParsingError)
+            }
+        } else {
+            Err(EDHOCError::ParsingError)
+        }
+    }
+
+    pub fn parse_message_1(
+        rcvd_message_1: &BufferMessage1,
+    ) -> Result<
+        (
+            u8,
+            BytesSuites,
+            usize,
+            BytesP256ElemLen,
+            u8,
+            Option<EADItem>,
+        ),
+        EDHOCError,
+    > {
+        let suites_i: BytesSuites;
+        let suites_i_len: usize;
+        let mut g_x: BytesP256ElemLen = [0x00; P256_ELEM_LEN];
+
+        let mut decoder = CBORDecoder::new(rcvd_message_1.as_slice());
+
+        let method = decoder.u8()?;
+
+        if let Ok(res) = parse_suites_i(decoder) {
+            (suites_i, suites_i_len, decoder) = res;
+        } else {
+            return Err(EDHOCError::ParsingError);
+        }
+
+        g_x.copy_from_slice(decoder.bytes_sized(P256_ELEM_LEN)?);
+
+        // consume c_i encoded as single-byte int (we still do not support bstr encoding)
+        let c_i = decoder.int_raw()?;
+
+        // if there is still more to parse, the rest will be the EAD_1
+        if rcvd_message_1.len > decoder.position() {
+            // NOTE: since the current implementation only supports one EAD handler,
+            // we assume only one EAD item
+            let ead_res = parse_ead(decoder.remaining_buffer()?);
+            if ead_res.is_ok() {
+                let ead_1 = ead_res.unwrap();
+                Ok((method, suites_i, suites_i_len, g_x, c_i, ead_1))
+            } else {
+                Err(ead_res.unwrap_err())
+            }
+        } else {
+            decoder.ensure_finished()?;
+            Ok((method, suites_i, suites_i_len, g_x, c_i, None))
+        }
+    }
+
+    pub fn parse_message_2(
+        rcvd_message_2: &BufferMessage2,
+    ) -> Result<(BytesP256ElemLen, BufferCiphertext2), EDHOCError> {
+        // FIXME decode negative integers as well
+        let mut ciphertext_2: BufferCiphertext2 = BufferCiphertext2::new();
+
+        let mut decoder = CBORDecoder::new(rcvd_message_2.as_slice());
+
+        // message_2 consists of 1 bstr element; this element in turn contains the concatenation of g_y and ciphertext_2
+        let decoded = decoder.bytes()?;
+        decoder.ensure_finished()?;
+
+        if let Some(key) = decoded.get(0..P256_ELEM_LEN) {
+            let mut g_y: BytesP256ElemLen = [0x00; P256_ELEM_LEN];
+            g_y.copy_from_slice(key);
+            if let Some(c2) = decoded.get(P256_ELEM_LEN..) {
+                ciphertext_2.len = c2.len(); // len - gy_len - 2
+                ciphertext_2.content[..ciphertext_2.len].copy_from_slice(c2);
+                Ok((g_y, ciphertext_2))
+            } else {
+                Err(EDHOCError::ParsingError)
+            }
+        } else {
+            Err(EDHOCError::ParsingError)
+        }
+    }
+
+    pub fn decode_plaintext_2(
+        plaintext_2: &BytesMaxBuffer,
+        plaintext_2_len: usize,
+    ) -> Result<(u8, IdCred, BytesMac2, Option<EADItem>), EDHOCError> {
+        let id_cred_r: IdCred;
+        let mut mac_2: BytesMac2 = [0x00; MAC_LENGTH_2];
+
+        let mut decoder = CBORDecoder::new(&plaintext_2[..plaintext_2_len]);
+
+        let c_r = decoder.int_raw()?;
+
+        // NOTE: if len of bstr is 1, it is a compact kid and therefore should have been encoded as int
+        if CBOR_MAJOR_BYTE_STRING == CBORDecoder::type_of(decoder.current()?)
+            && CBORDecoder::info_of(decoder.current()?) > 1
+        {
+            id_cred_r = IdCred::FullCredential(decoder.bytes()?);
+        } else {
+            id_cred_r = IdCred::CompactKid(decoder.int_raw()?);
+        }
+
+        mac_2[..].copy_from_slice(decoder.bytes_sized(MAC_LENGTH_2)?);
+
+        // if there is still more to parse, the rest will be the EAD_2
+        if plaintext_2_len > decoder.position() {
+            // assume only one EAD item
+            let ead_res = parse_ead(decoder.remaining_buffer()?);
+            if ead_res.is_ok() {
+                let ead_2 = ead_res.unwrap();
+                Ok((c_r, id_cred_r, mac_2, ead_2))
+            } else {
+                Err(ead_res.unwrap_err())
+            }
+        } else {
+            decoder.ensure_finished()?;
+            Ok((c_r, id_cred_r, mac_2, None))
+        }
+    }
+
+    pub fn decode_plaintext_3(
+        plaintext_3: &BufferPlaintext3,
+    ) -> Result<(IdCred, BytesMac3, Option<EADItem>), EDHOCError> {
+        let mut mac_3: BytesMac3 = [0x00; MAC_LENGTH_3];
+        let id_cred_i: IdCred;
+
+        let mut decoder = CBORDecoder::new(plaintext_3.as_slice());
+
+        // NOTE: if len of bstr is 1, then it is a compact kid and therefore should have been encoded as int
+        if CBOR_MAJOR_BYTE_STRING == CBORDecoder::type_of(decoder.current()?)
+            && CBORDecoder::info_of(decoder.current()?) > 1
+        {
+            id_cred_i = IdCred::FullCredential(decoder.bytes()?);
+        } else {
+            id_cred_i = IdCred::CompactKid(decoder.int_raw()?);
+        }
+
+        mac_3[..].copy_from_slice(decoder.bytes_sized(MAC_LENGTH_3)?);
+
+        // if there is still more to parse, the rest will be the EAD_3
+        if plaintext_3.len > decoder.position() {
+            // assume only one EAD item
+            let ead_res = parse_ead(decoder.remaining_buffer()?);
+            if ead_res.is_ok() {
+                let ead_3 = ead_res.unwrap();
+                Ok((id_cred_i, mac_3, ead_3))
+            } else {
+                Err(ead_res.unwrap_err())
+            }
+        } else {
+            decoder.ensure_finished()?;
+            Ok((id_cred_i, mac_3, None))
+        }
+    }
+}
+
+mod cbor_decoder {
+    /// Decoder inspired by the [minicbor](https://crates.io/crates/minicbor) crate.
+    use super::*;
+
+    #[derive(Debug)]
+    pub enum CBORError {
+        DecodingError,
+    }
+
+    impl From<CBORError> for EDHOCError {
+        fn from(error: CBORError) -> Self {
+            match error {
+                CBORError::DecodingError => EDHOCError::ParsingError,
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct CBORDecoder<'a> {
+        buf: &'a [u8],
+        pos: usize,
+    }
+
+    impl<'a> CBORDecoder<'a> {
+        pub fn new(bytes: &'a [u8]) -> Self {
+            CBORDecoder { buf: bytes, pos: 0 }
+        }
+
+        fn read(&mut self) -> Result<u8, CBORError> {
+            if let Some(b) = self.buf.get(self.pos) {
+                self.pos += 1;
+                return Ok(*b);
+            }
+            Err(CBORError::DecodingError)
+        }
+
+        /// Consume and return *n* bytes starting at the current position.
+        fn read_slice(&mut self, n: usize) -> Result<&'a [u8], CBORError> {
+            if let Some(b) = self
+                .pos
+                .checked_add(n)
+                .and_then(|end| self.buf.get(self.pos..end))
+            {
+                self.pos += n;
+                return Ok(b);
+            }
+            Err(CBORError::DecodingError)
+        }
+
+        pub fn position(&self) -> usize {
+            self.pos
+        }
+
+        pub fn finished(&self) -> bool {
+            self.pos == self.buf.len()
+        }
+
+        pub fn ensure_finished(&self) -> Result<(), CBORError> {
+            if self.finished() {
+                Ok(())
+            } else {
+                Err(CBORError::DecodingError)
+            }
+        }
+
+        pub fn remaining_buffer(&self) -> Result<&[u8], CBORError> {
+            if let Some(buffer) = self.buf.get(self.pos..) {
+                Ok(buffer)
+            } else {
+                Err(CBORError::DecodingError)
+            }
+        }
+
+        /// Get the byte at the current position.
+        pub fn current(&self) -> Result<u8, CBORError> {
+            if let Some(b) = self.buf.get(self.pos) {
+                return Ok(*b);
+            }
+            Err(CBORError::DecodingError)
+        }
+
+        /// Decode a `u8` value.
+        pub fn u8(&mut self) -> Result<u8, CBORError> {
+            match self.read()? {
+                n @ 0..=0x17 => Ok(n),
+                0x18 => self.read(),
+                _ => Err(CBORError::DecodingError),
+            }
+        }
+
+        /// Decode an `i8` value.
+        pub fn i8(&mut self) -> Result<i8, CBORError> {
+            match self.read()? {
+                n @ 0x00..=0x17 => Ok(n as i8),
+                n @ 0x20..=0x37 => Ok(-1 - (n - 0x20) as i8),
+                _b => Err(CBORError::DecodingError),
+            }
+        }
+
+        /// Get the raw `i8` or `u8` value.
+        pub fn int_raw(&mut self) -> Result<u8, CBORError> {
+            match self.read()? {
+                n @ 0x00..=0x17 => Ok(n),
+                n @ 0x20..=0x37 => Ok(n),
+                _b => Err(CBORError::DecodingError),
+            }
+        }
+
+        /// Decode a string slice.
+        pub fn str(&mut self) -> Result<&'a [u8], CBORError> {
+            let p = self.pos;
+            let b = self.read()?;
+            if CBOR_MAJOR_TEXT_STRING != Self::type_of(b) || Self::info_of(b) == 31 {
+                return Err(CBORError::DecodingError);
+            }
+            let n = self.as_usize(Self::info_of(b))?;
+            self.read_slice(n)
+        }
+
+        /// Decode a byte slice.
+        pub fn bytes(&mut self) -> Result<&'a [u8], CBORError> {
+            let p = self.pos;
+            let b = self.read()?;
+            if CBOR_MAJOR_BYTE_STRING != Self::type_of(b) || Self::info_of(b) == 31 {
+                return Err(CBORError::DecodingError);
+            }
+            let n = self.as_usize(Self::info_of(b))?;
+            self.read_slice(n)
+        }
+
+        /// Decode a byte slice of an expected size.
+        pub fn bytes_sized(&mut self, expected_size: usize) -> Result<&'a [u8], CBORError> {
+            let res = self.bytes()?;
+            if res.len() == expected_size {
+                Ok(res)
+            } else {
+                Err(CBORError::DecodingError)
+            }
+        }
+
+        /// Begin decoding an array.
+        pub fn array(&mut self) -> Result<usize, CBORError> {
+            let p = self.pos;
+            let b = self.read()?;
+            if CBOR_MAJOR_ARRAY != Self::type_of(b) {
+                return Err(CBORError::DecodingError);
+            }
+            match Self::info_of(b) {
+                31 => Err(CBORError::DecodingError), // no support for unknown size arrays
+                n => Ok(self.as_usize(n)?),
+            }
+        }
+
+        /// Decode a `u8` value into usize.
+        pub fn as_usize(&mut self, b: u8) -> Result<usize, CBORError> {
+            match b {
+                n @ 0..=0x17 => Ok(usize::from(n)),
+                0x18 => self.read().map(usize::from),
+                _ => Err(CBORError::DecodingError),
+            }
+        }
+
+        /// Get the major type info of the given byte (highest 3 bits).
+        pub fn type_of(b: u8) -> u8 {
+            b & 0b111_00000
+        }
+
+        /// Get the additionl type info of the given byte (lowest 5 bits).
+        pub fn info_of(b: u8) -> u8 {
+            b & 0b000_11111
+        }
+
+        /// Check for: an unsigned integer encoded as a single byte
+        pub fn is_u8(byte: u8) -> bool {
+            return byte >= CBOR_UINT_1BYTE_START && byte <= CBOR_UINT_1BYTE_END;
+        }
+
+        /// Check for: a negative integer encoded as a single byte
+        pub fn is_i8(byte: u8) -> bool {
+            return byte >= CBOR_NEG_INT_1BYTE_START && byte <= CBOR_NEG_INT_1BYTE_END;
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_cbor_decoder {
+    use super::cbor_decoder::*;
+
+    #[test]
+    fn test_cbor_decoder() {
+        // CBOR sequence: 1, -1, "hi", h'fefe'
+        let input = [0x01, 0x20, 0x62, 0x68, 0x69, 0x42, 0xFE, 0xFE];
+        let mut decoder = CBORDecoder::new(&input);
+
+        assert_eq!(1, decoder.u8().unwrap());
+        assert_eq!(-1, decoder.i8().unwrap());
+        assert_eq!([0x68, 0x69], decoder.str().unwrap()); // "hi"
+        assert_eq!([0xFE, 0xFE], decoder.bytes().unwrap());
     }
 }

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -873,35 +873,6 @@ fn encode_message_1(
     output
 }
 
-fn parse_message_2(
-    rcvd_message_2: &BufferMessage2,
-) -> Result<(BytesP256ElemLen, BufferCiphertext2), EDHOCError> {
-    let mut error: EDHOCError = EDHOCError::UnknownError;
-    // FIXME decode negative integers as well
-    let mut g_y: BytesP256ElemLen = [0x00; P256_ELEM_LEN];
-    let mut ciphertext_2: BufferCiphertext2 = BufferCiphertext2::new();
-
-    // ensure the whole message is a single CBOR sequence
-    if is_cbor_bstr_2bytes_prefix(rcvd_message_2.content[0])
-        && rcvd_message_2.content[1] == (rcvd_message_2.len as u8 - 2)
-    {
-        g_y[..].copy_from_slice(&rcvd_message_2.content[2..2 + P256_ELEM_LEN]);
-
-        ciphertext_2.len = rcvd_message_2.len - P256_ELEM_LEN - 2; // len - gy_len - 2
-        ciphertext_2.content[..ciphertext_2.len].copy_from_slice(
-            &rcvd_message_2.content[2 + P256_ELEM_LEN..2 + P256_ELEM_LEN + ciphertext_2.len],
-        );
-        error = EDHOCError::Success;
-    } else {
-        error = EDHOCError::ParsingError;
-    }
-
-    match error {
-        EDHOCError::Success => Ok((g_y, ciphertext_2)),
-        _ => Err(error),
-    }
-}
-
 fn encode_message_2(g_y: &BytesP256ElemLen, ciphertext_2: &BufferCiphertext2) -> BufferMessage2 {
     let mut output: BufferMessage2 = BufferMessage2::new();
 
@@ -990,73 +961,6 @@ fn edhoc_kdf(
     let (info, info_len) = encode_info(label, context, context_len, length);
     let output = crypto.hkdf_expand(prk, &info, info_len, length);
     output
-}
-
-fn decode_plaintext_3(
-    plaintext_3: &BufferPlaintext3,
-) -> Result<(IdCred, BytesMac3, Option<EADItem>), EDHOCError> {
-    let mut ead_3 = None::<EADItem>;
-    let mut error = EDHOCError::UnknownError;
-    let mut kid: u8 = 0xff;
-    let mut mac_3: BytesMac3 = [0x00; MAC_LENGTH_3];
-    let mut id_cred_i: IdCred = IdCred::CompactKid(0xFF);
-
-    // check ID_CRED_I and MAC_3
-    let res = if (is_cbor_neg_int_1byte(plaintext_3.content[0])
-        || is_cbor_uint_1byte(plaintext_3.content[0]))
-    {
-        // KID
-        kid = plaintext_3.content[0usize];
-        id_cred_i = IdCred::CompactKid(plaintext_3.content[0usize]);
-        Ok(1)
-    } else if is_cbor_bstr_2bytes_prefix(plaintext_3.content[0])
-        && is_cbor_uint_2bytes(plaintext_3.content[1])
-        && (plaintext_3.content[2] as usize) < plaintext_3.len
-    {
-        // full credential
-        let cred_len = plaintext_3.content[2] as usize;
-        id_cred_i = IdCred::FullCredential(&plaintext_3.content[3..3 + cred_len]);
-        Ok(3 + cred_len)
-    } else {
-        // error
-        Err(())
-    };
-
-    if res.is_ok() {
-        let mut offset = res.unwrap();
-
-        if (is_cbor_bstr_1byte_prefix(plaintext_3.content[1])) {
-            // skip the CBOR magic byte as we know how long the MAC is
-            offset += 1;
-            mac_3[..].copy_from_slice(&plaintext_3.content[offset..offset + MAC_LENGTH_3]);
-
-            // if there is still more to parse, the rest will be the EAD_3
-            if plaintext_3.len > (offset + MAC_LENGTH_3) {
-                // NOTE: since the current implementation only supports one EAD handler,
-                // we assume only one EAD item
-                let ead_res = parse_ead(plaintext_3, offset + MAC_LENGTH_3);
-                if ead_res.is_ok() {
-                    ead_3 = ead_res.unwrap();
-                    error = EDHOCError::Success;
-                } else {
-                    error = ead_res.unwrap_err();
-                }
-            } else if plaintext_3.len == (offset + MAC_LENGTH_3) {
-                error = EDHOCError::Success;
-            } else {
-                error = EDHOCError::ParsingError;
-            }
-        } else {
-            error = EDHOCError::ParsingError;
-        }
-    } else {
-        error = EDHOCError::ParsingError;
-    }
-
-    match error {
-        EDHOCError::Success => Ok((id_cred_i, mac_3, ead_3)),
-        _ => Err(error),
-    }
 }
 
 fn encode_plaintext_3(
@@ -1265,71 +1169,6 @@ fn compute_mac_2(
     mac_2
 }
 
-fn decode_plaintext_2(
-    plaintext_2: &BytesMaxBuffer,
-    plaintext_2_len: usize,
-) -> Result<(u8, IdCred, BytesMac2, Option<EADItem>), EDHOCError> {
-    let mut error = EDHOCError::UnknownError;
-    let mut ead_2 = None::<EADItem>;
-    let mut c_r: u8 = 0xff;
-    let mut id_cred_r: IdCred = IdCred::CompactKid(0xFF);
-    let mut mac_2: BytesMac2 = [0x00; MAC_LENGTH_2];
-
-    if (is_cbor_neg_int_1byte(plaintext_2[0]) || is_cbor_uint_1byte(plaintext_2[0])) {
-        c_r = plaintext_2[0];
-
-        let res = if is_cbor_neg_int_1byte(plaintext_2[1]) || is_cbor_uint_1byte(plaintext_2[1]) {
-            id_cred_r = IdCred::CompactKid(plaintext_2[1]);
-            Ok(2)
-        } else if is_cbor_bstr_2bytes_prefix(plaintext_2[1])
-            && is_cbor_uint_2bytes(plaintext_2[2])
-            && (plaintext_2[3] as usize) < plaintext_2_len
-        {
-            let cred_len = plaintext_2[3] as usize;
-            id_cred_r = IdCred::FullCredential(&plaintext_2[4..4 + cred_len]);
-            Ok(4 + cred_len)
-        } else {
-            Err(())
-        };
-
-        if res.is_ok() {
-            let mut offset = res.unwrap();
-            // skip cbor string byte as we know how long the string is
-            offset += 1;
-            mac_2[..].copy_from_slice(&plaintext_2[offset..offset + MAC_LENGTH_2]);
-
-            // if there is still more to parse, the rest will be the EAD_2
-            if plaintext_2_len > (offset + MAC_LENGTH_2) {
-                // NOTE: since the current implementation only supports one EAD handler,
-                // we assume only one EAD item
-                let ead_res = parse_ead(
-                    &plaintext_2[..plaintext_2_len].try_into().expect("too long"),
-                    offset + MAC_LENGTH_2,
-                );
-                if ead_res.is_ok() {
-                    ead_2 = ead_res.unwrap();
-                    error = EDHOCError::Success;
-                } else {
-                    error = ead_res.unwrap_err();
-                }
-            } else if plaintext_2_len == (offset + MAC_LENGTH_2) {
-                error = EDHOCError::Success;
-            } else {
-                error = EDHOCError::ParsingError;
-            }
-        } else {
-            error = EDHOCError::ParsingError;
-        }
-    } else {
-        error = EDHOCError::ParsingError;
-    }
-
-    match error {
-        EDHOCError::Success => Ok((c_r, id_cred_r, mac_2, ead_2)),
-        _ => Err(error),
-    }
-}
-
 fn encode_plaintext_2(
     c_r: u8,
     id_cred_r: IdCred,
@@ -1347,10 +1186,9 @@ fn encode_plaintext_2(
         }
         IdCred::FullCredential(cred) => {
             plaintext_2.content[1] = CBOR_BYTE_STRING;
-            plaintext_2.content[2] = CBOR_UINT_1BYTE;
-            plaintext_2.content[3] = cred.len() as u8;
-            plaintext_2.content[4..4 + cred.len()].copy_from_slice(cred);
-            4 + cred.len()
+            plaintext_2.content[2] = cred.len() as u8;
+            plaintext_2.content[3..3 + cred.len()].copy_from_slice(cred);
+            3 + cred.len()
         }
     };
 
@@ -1618,32 +1456,48 @@ mod tests {
     #[test]
     fn test_parse_suites_i() {
         let message_1_tv = BufferMessage1::from_hex(MESSAGE_1_TV);
-
-        let res = parse_suites_i(&message_1_tv);
+        // skip the fist byte (method)
+        let mut decoder = CBORDecoder::new(&message_1_tv.content[1..message_1_tv.len]);
+        let res = parse_suites_i(decoder);
         assert!(res.is_ok());
-        let (suites_i, suites_i_len, raw_suites_len) = res.unwrap();
+        let (suites_i, suites_i_len, _decoder) = res.unwrap();
         assert_eq!(suites_i, SUITES_I_TV);
 
-        let res = parse_suites_i(&BufferMessage1::from_hex(MESSAGE_1_TV_SUITE_ONLY_A));
+        let message_1_tv = BufferMessage1::from_hex(MESSAGE_1_TV_SUITE_ONLY_A);
+        // skip the fist byte (method)
+        let mut decoder = CBORDecoder::new(&message_1_tv.content[1..message_1_tv.len]);
+        let res = parse_suites_i(decoder);
         assert!(res.is_ok());
-        let (suites_i, suites_i_len, raw_suites_len) = res.unwrap();
+        let (suites_i, suites_i_len, _decoder) = res.unwrap();
         assert_eq!(suites_i[0], 0x18);
 
-        let (suites_i, suites_i_len, raw_suites_len) =
-            parse_suites_i(&BufferMessage1::from_hex(MESSAGE_1_TV_SUITE_ONLY_B)).unwrap();
+        // let (suites_i, suites_i_len, raw_suites_len) =
+        //     parse_suites_i(&BufferMessage1::from_hex(MESSAGE_1_TV_SUITE_ONLY_B)).unwrap();
+
+        let message_1_tv = BufferMessage1::from_hex(MESSAGE_1_TV_SUITE_ONLY_B);
+        // skip the fist byte (method)
+        let mut decoder = CBORDecoder::new(&message_1_tv.content[1..message_1_tv.len]);
+        let res = parse_suites_i(decoder);
+        assert!(res.is_ok());
+        let (suites_i, suites_i_len, _decoder) = res.unwrap();
         assert_eq!(suites_i_len, 2);
-        assert_eq!(raw_suites_len, 3);
         assert_eq!(suites_i[0], 0x02);
         assert_eq!(suites_i[1], 0x01);
 
-        let (suites_i, suites_i_len, raw_suites_len) =
-            parse_suites_i(&BufferMessage1::from_hex(MESSAGE_1_TV_SUITE_ONLY_C)).unwrap();
+        let message_1_tv = BufferMessage1::from_hex(MESSAGE_1_TV_SUITE_ONLY_C);
+        // skip the fist byte (method)
+        let mut decoder = CBORDecoder::new(&message_1_tv.content[1..message_1_tv.len]);
+        let res = parse_suites_i(decoder);
+        assert!(res.is_ok());
+        let (suites_i, suites_i_len, _decoder) = res.unwrap();
         assert_eq!(suites_i_len, 2);
-        assert_eq!(raw_suites_len, 4);
         assert_eq!(suites_i[0], 0x02);
         assert_eq!(suites_i[1], 0x19);
 
-        let res = parse_suites_i(&BufferMessage1::from_hex(MESSAGE_1_TV_SUITE_ONLY_ERR));
+        let message_1_tv = BufferMessage1::from_hex(MESSAGE_1_TV_SUITE_ONLY_ERR);
+        // skip the fist byte (method)
+        let mut decoder = CBORDecoder::new(&message_1_tv.content[1..message_1_tv.len]);
+        let res = parse_suites_i(decoder);
         assert_eq!(res.unwrap_err(), EDHOCError::ParsingError);
     }
 
@@ -2010,7 +1864,7 @@ mod tests {
         let message_ead_tv = BufferMessage1::from_hex(MESSAGE_1_WITH_DUMMY_EAD_TV);
         let ead_value_tv = EdhocMessageBuffer::from_hex(EAD_DUMMY_VALUE_TV);
 
-        let res = parse_ead(&message_ead_tv, message_tv_offset);
+        let res = parse_ead(&message_ead_tv.content[message_tv_offset..message_ead_tv.len]);
         assert!(res.is_ok());
         let ead_item = res.unwrap();
         assert!(ead_item.is_some());
@@ -2021,7 +1875,8 @@ mod tests {
 
         let message_ead_tv = BufferMessage1::from_hex(MESSAGE_1_WITH_DUMMY_CRITICAL_EAD_TV);
 
-        let res = parse_ead(&message_ead_tv, message_tv_offset).unwrap();
+        let res =
+            parse_ead(&message_ead_tv.content[message_tv_offset..message_ead_tv.len]).unwrap();
         let ead_item = res.unwrap();
         assert!(ead_item.is_critical);
         assert_eq!(ead_item.label, EAD_DUMMY_LABEL_TV);
@@ -2029,7 +1884,8 @@ mod tests {
 
         let message_ead_tv = BufferMessage1::from_hex(MESSAGE_1_WITH_DUMMY_EAD_NO_VALUE_TV);
 
-        let res = parse_ead(&message_ead_tv, message_tv_offset).unwrap();
+        let res =
+            parse_ead(&message_ead_tv.content[message_tv_offset..message_ead_tv.len]).unwrap();
         let ead_item = res.unwrap();
         assert!(!ead_item.is_critical);
         assert_eq!(ead_item.label, EAD_DUMMY_LABEL_TV);


### PR DESCRIPTION
Applying PR #140 to the hax branch.

Generated `fstar` files here: [edhoc-rs-fstar-20nov2023-10h27.zip](https://github.com/openwsn-berkeley/edhoc-rs/files/13412052/edhoc-rs-fstar-20nov2023-10h27.zip)

Command:

```bash
cargo-hax -C -p edhoc-rs -p edhoc-consts  --no-default-features --features="crypto-hacspec, ead-none" \; into -i '-edhoc_rs::generate_connection_identifier_cbor -edhoc_rs::generate_connection_identifier' fstar
```