### PR TITLE
Warning fixes

### DIFF
--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -555,13 +555,12 @@ mod edhoc_parser {
     }
 
     pub fn decode_plaintext_2(
-        plaintext_2: &BytesMaxBuffer,
-        plaintext_2_len: usize,
+        plaintext_2: &BufferCiphertext2,
     ) -> Result<(u8, IdCred, BytesMac2, Option<EADItem>), EDHOCError> {
         let id_cred_r: IdCred;
         let mut mac_2: BytesMac2 = [0x00; MAC_LENGTH_2];
 
-        let mut decoder = CBORDecoder::new(&plaintext_2[..plaintext_2_len]);
+        let mut decoder = CBORDecoder::new(&plaintext_2.content[..plaintext_2.len]);
 
         let c_r = decoder.int_raw()?;
 
@@ -577,7 +576,7 @@ mod edhoc_parser {
         mac_2[..].copy_from_slice(decoder.bytes_sized(MAC_LENGTH_2)?);
 
         // if there is still more to parse, the rest will be the EAD_2
-        if plaintext_2_len > decoder.position() {
+        if plaintext_2.len > decoder.position() {
             // assume only one EAD item
             let ead_res = parse_ead(decoder.remaining_buffer()?);
             if ead_res.is_ok() {

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -738,7 +738,6 @@ mod cbor_decoder {
 
         /// Decode a string slice.
         pub fn str(&mut self) -> Result<&'a [u8], CBORError> {
-            let p = self.pos;
             let b = self.read()?;
             if CBOR_MAJOR_TEXT_STRING != Self::type_of(b) || Self::info_of(b) == 31 {
                 return Err(CBORError::DecodingError);
@@ -749,7 +748,6 @@ mod cbor_decoder {
 
         /// Decode a byte slice.
         pub fn bytes(&mut self) -> Result<&'a [u8], CBORError> {
-            let p = self.pos;
             let b = self.read()?;
             if CBOR_MAJOR_BYTE_STRING != Self::type_of(b) || Self::info_of(b) == 31 {
                 return Err(CBORError::DecodingError);
@@ -770,7 +768,6 @@ mod cbor_decoder {
 
         /// Begin decoding an array.
         pub fn array(&mut self) -> Result<usize, CBORError> {
-            let p = self.pos;
             let b = self.read()?;
             if CBOR_MAJOR_ARRAY != Self::type_of(b) {
                 return Err(CBORError::DecodingError);

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -82,8 +82,8 @@ pub fn r_process_message_1(
     let State(
         _current_state,
         _y,
-        mut c_i,
-        g_x,
+        _c_i,
+        _g_x,
         _prk_3e2m,
         _prk_4e3m,
         _prk_out,
@@ -427,7 +427,7 @@ pub fn i_process_message_2(
         _current_state,
         x,
         _c_i,
-        g_y,
+        _g_y,
         mut prk_3e2m,
         mut prk_4e3m,
         _prk_out,
@@ -874,8 +874,8 @@ fn decode_plaintext_3(
     let id_cred_i: IdCred;
 
     // check ID_CRED_I and MAC_3
-    let res = if (is_cbor_neg_int_1byte(plaintext_3.content[0])
-        || is_cbor_uint_1byte(plaintext_3.content[0]))
+    let res = if is_cbor_neg_int_1byte(plaintext_3.content[0])
+        || is_cbor_uint_1byte(plaintext_3.content[0])
     {
         // KID
         kid = plaintext_3.content[0usize];
@@ -897,7 +897,7 @@ fn decode_plaintext_3(
     if res.is_ok() {
         let (mut offset, id_cred_i) = res.unwrap();
 
-        if (is_cbor_bstr_1byte_prefix(plaintext_3.content[1])) {
+        if is_cbor_bstr_1byte_prefix(plaintext_3.content[1]) {
             // skip the CBOR magic byte as we know how long the MAC is
             offset += 1;
             mac_3[..].copy_from_slice(&plaintext_3.content[offset..offset + MAC_LENGTH_3]);
@@ -1134,7 +1134,7 @@ fn decode_plaintext_2(
     let mut id_cred_r: IdCred = IdCred::CompactKid(0xFF);
     let mut mac_2: BytesMac2 = [0x00; MAC_LENGTH_2];
 
-    if (is_cbor_neg_int_1byte(plaintext_2[0]) || is_cbor_uint_1byte(plaintext_2[0])) {
+    if is_cbor_neg_int_1byte(plaintext_2[0]) || is_cbor_uint_1byte(plaintext_2[0]) {
         let c_r = plaintext_2[0];
 
         let res = if is_cbor_neg_int_1byte(plaintext_2[1]) || is_cbor_uint_1byte(plaintext_2[1]) {

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -1,5 +1,3 @@
-#![no_std]
-
 use core::marker::PhantomData;
 use edhoc_consts::{Crypto as CryptoTrait, *};
 use edhoc_ead::*;

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -45,10 +45,8 @@ pub fn edhoc_key_update(
         _th_3,
     ) = state;
 
-    let mut prk_new_buf: BytesMaxBuffer;
-
     // new PRK_out
-    prk_new_buf = edhoc_kdf(
+    let prk_new_buf = edhoc_kdf(
         crypto,
         &prk_out,
         11u8,
@@ -59,7 +57,7 @@ pub fn edhoc_key_update(
     prk_out[..SHA256_DIGEST_LEN].copy_from_slice(&prk_new_buf[..SHA256_DIGEST_LEN]);
 
     // new PRK_exporter
-    prk_new_buf = edhoc_kdf(
+    let prk_new_buf = edhoc_kdf(
         crypto,
         &prk_out,
         10u8,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(test), no_std)]
-#![allow(warnings)]
 
 pub use {edhoc_consts::Crypto as CryptoTrait, edhoc_consts::State as EdhocState, edhoc_consts::*};
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -29,9 +29,7 @@ pub struct EdhocInitiatorWaitM2<'a, Crypto: CryptoTrait> {
 #[derive(Debug)]
 pub struct EdhocInitiatorBuildM3<'a, Crypto: CryptoTrait> {
     state: State<ProcessedMessage2>, // opaque state
-    i: &'a [u8],                     // private authentication key of I
     cred_i: &'a [u8],                // I's full credential
-    cred_r: Option<&'a [u8]>,        // R's full credential (if provided)
     crypto: Crypto,
 }
 
@@ -62,8 +60,6 @@ pub struct EdhocResponderBuildM2<'a, Crypto: CryptoTrait> {
 #[derive(Debug)]
 pub struct EdhocResponderWaitM3<'a, Crypto: CryptoTrait> {
     state: State<WaitMessage3>, // opaque state
-    r: &'a [u8],                // private authentication key of R
-    cred_r: &'a [u8],           // R's full credential
     cred_i: Option<&'a [u8]>,   // I's full credential (if provided)
     crypto: Crypto,
 }
@@ -128,8 +124,6 @@ impl<'a, Crypto: CryptoTrait> EdhocResponderBuildM2<'a, Crypto> {
             Ok((state, message_2)) => Ok((
                 EdhocResponderWaitM3 {
                     state,
-                    r: self.r,
-                    cred_r: self.cred_r,
                     cred_i: self.cred_i,
                     crypto: self.crypto,
                 },
@@ -249,9 +243,7 @@ impl<'a, Crypto: CryptoTrait> EdhocInitiatorWaitM2<'a, Crypto> {
             Ok((state, c_r, _kid)) => Ok((
                 EdhocInitiatorBuildM3 {
                     state,
-                    i: self.i,
                     cred_i: self.cred_i,
-                    cred_r: self.cred_r,
                     crypto: self.crypto,
                 },
                 c_r,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -8,8 +8,6 @@ pub use edhoc_ead::*;
 mod edhoc;
 use edhoc::*;
 
-use edhoc_consts::*;
-
 #[derive(Debug)]
 pub struct EdhocInitiator<'a, Crypto: CryptoTrait> {
     state: State<Start>,      // opaque state
@@ -350,7 +348,7 @@ pub fn generate_connection_identifier<Crypto: CryptoTrait>(crypto: &mut Crypto) 
 #[cfg(test)]
 mod test {
     use super::*;
-    use edhoc_consts::*;
+
     use hexlit::hex;
 
     use edhoc_crypto::default_crypto;
@@ -391,7 +389,7 @@ mod test {
     #[test]
     fn test_prepare_message_1() {
         let state = Default::default();
-        let mut initiator = EdhocInitiator::new(state, default_crypto(), I, CRED_I, Some(CRED_R));
+        let initiator = EdhocInitiator::new(state, default_crypto(), I, CRED_I, Some(CRED_R));
 
         let c_i = generate_connection_identifier_cbor(&mut default_crypto());
         let message_1 = initiator.prepare_message_1(c_i);
@@ -430,7 +428,7 @@ mod test {
     #[test]
     fn test_handshake() {
         let state_initiator = Default::default();
-        let mut initiator =
+        let initiator =
             EdhocInitiator::new(state_initiator, default_crypto(), I, CRED_I, Some(CRED_R));
         let state_responder = Default::default();
         let responder =


### PR DESCRIPTION
Based on #142, this removes the `#![allow(warnings)]` (which AIU is a remnant of how early hacspec required writing code that the linter would be unhappy about), and applies a lot of small refactoring fixes that would probably just have been caught at write time / when they were earlier refactored into the current state.