### PR TITLE
fix: Restore hacspec tests after crypto trait refactoring

### DIFF
--- a/crypto/edhoc-crypto-hacspec/src/lib.rs
+++ b/crypto/edhoc-crypto-hacspec/src/lib.rs
@@ -220,14 +220,14 @@ mod tests {
 
     #[test]
     fn test_p256_keys() {
-        let (x, g_x) = p256_generate_key_pair();
+        let (x, g_x) = Crypto.p256_generate_key_pair();
         assert_eq!(x.len(), 32);
         assert_eq!(g_x.len(), 32);
 
-        let (y, g_y) = p256_generate_key_pair();
+        let (y, g_y) = Crypto.p256_generate_key_pair();
 
-        let g_xy = p256_ecdh(&x, &g_y);
-        let g_yx = p256_ecdh(&y, &g_x);
+        let g_xy = Crypto.p256_ecdh(&x, &g_y);
+        let g_yx = Crypto.p256_ecdh(&y, &g_x);
 
         assert_eq!(g_xy, g_yx);
     }


### PR DESCRIPTION
Cherry pick of #147, but in a separate PR to avoid having to merge main into the PR branch.