### PR TITLE
refactor: Apply suggestions from clippy

### DIFF
--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -753,9 +753,7 @@ fn compute_th_2(
 
     let len = 4 + P256_ELEM_LEN + SHA256_DIGEST_LEN;
 
-    let th_2 = crypto.sha256_digest(&message, len);
-
-    th_2
+    crypto.sha256_digest(&message, len)
 }
 
 fn compute_th_3(
@@ -774,9 +772,7 @@ fn compute_th_3(
     message[2 + th_2.len() + plaintext_2.len..2 + th_2.len() + plaintext_2.len + cred_r.len()]
         .copy_from_slice(cred_r);
 
-    let output = crypto.sha256_digest(&message, th_2.len() + 2 + plaintext_2.len + cred_r.len());
-
-    output
+    crypto.sha256_digest(&message, th_2.len() + 2 + plaintext_2.len + cred_r.len())
 }
 
 fn compute_th_4(
@@ -795,9 +791,7 @@ fn compute_th_4(
     message[2 + th_3.len() + plaintext_3.len..2 + th_3.len() + plaintext_3.len + cred_i.len()]
         .copy_from_slice(cred_i);
 
-    let output = crypto.sha256_digest(&message, th_3.len() + 2 + plaintext_3.len + cred_i.len());
-
-    output
+    crypto.sha256_digest(&message, th_3.len() + 2 + plaintext_3.len + cred_i.len())
 }
 
 // TODO: consider moving this to a new 'edhoc crypto primitives' module
@@ -1103,9 +1097,8 @@ fn compute_prk_4e3m(
 ) -> BytesHashLen {
     // compute g_rx from static R's public key and private ephemeral key
     let g_iy = crypto.p256_ecdh(i, g_y);
-    let prk_4e3m = crypto.hkdf_extract(salt_4e3m, &g_iy);
 
-    prk_4e3m
+    crypto.hkdf_extract(salt_4e3m, &g_iy)
 }
 
 fn compute_salt_3e2m(
@@ -1139,9 +1132,8 @@ fn compute_prk_3e2m(
 ) -> BytesHashLen {
     // compute g_rx from static R's public key and private ephemeral key
     let g_rx = crypto.p256_ecdh(x, g_r);
-    let prk_3e2m = crypto.hkdf_extract(salt_3e2m, &g_rx);
 
-    prk_3e2m
+    crypto.hkdf_extract(salt_3e2m, &g_rx)
 }
 
 fn compute_prk_2e(
@@ -1153,9 +1145,8 @@ fn compute_prk_2e(
     // compute the shared secret
     let g_xy = crypto.p256_ecdh(x, g_y);
     // compute prk_2e as PRK_2e = HMAC-SHA-256( salt, G_XY )
-    let prk_2e = crypto.hkdf_extract(th_2, &g_xy);
 
-    prk_2e
+    crypto.hkdf_extract(th_2, &g_xy)
 }
 
 #[cfg(test)]

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -926,15 +926,12 @@ fn decrypt_message_3(
 
     let p3 = crypto.aes_ccm_decrypt_tag_8(&k_3, &iv_3, &enc_structure, &ciphertext_3);
 
-    if p3.is_ok() {
-        let p3 = p3.unwrap();
+    p3.map(|p3| {
         plaintext_3.content[..p3.len].copy_from_slice(&p3.content[..p3.len]);
         plaintext_3.len = p3.len;
 
-        Ok(plaintext_3)
-    } else {
-        Err(p3.unwrap_err())
-    }
+        plaintext_3
+    })
 }
 
 // output must hold id_cred.len() + cred.len()

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -434,8 +434,7 @@ pub fn i_process_message_2(
         // decode plaintext_2
         let plaintext_2_decoded = decode_plaintext_2(&plaintext_2);
 
-        if plaintext_2_decoded.is_ok() {
-            let (c_r_2, id_cred_r, mac_2, ead_2) = plaintext_2_decoded.unwrap();
+        if let Ok((c_r_2, id_cred_r, mac_2, ead_2)) = plaintext_2_decoded {
             let c_r = c_r_2;
 
             let cred_r = credential_check_or_fetch(cred_r_expected, id_cred_r);


### PR DESCRIPTION
The changes were hand-screened for whether they make sense in this particular case; most did.

Among other things, this replaces several returns with implicit returns, as is convenient for hax.

(Still a draft: This was just the ones a `cargo clippy -p edhoc-rs -p edhoc-crypto -p edhoc-consts -p edhoc-ead-zeroconf -p edhoc-ead-none --no-default-features --features="edhoc-crypto/rustcrypto, ead-none" --fix` produced, now starting to look at the output of clippy for more enhancements)