### PR TITLE
Improve message buffer access

### DIFF
--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -549,7 +549,7 @@ mod edhoc_parser {
         let id_cred_r: IdCred;
         let mut mac_2: BytesMac2 = [0x00; MAC_LENGTH_2];
 
-        let mut decoder = CBORDecoder::new(&plaintext_2.content[..plaintext_2.len]);
+        let mut decoder = CBORDecoder::new(plaintext_2.as_slice());
 
         let c_r = decoder.int_raw()?;
 

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -197,6 +197,16 @@ impl EdhocMessageBuffer {
         &self.content[0..self.len]
     }
 
+    pub fn fill_with_slice(&mut self, slice: &[u8]) -> Result<(), ()> {
+        if slice.len() <= self.content.len() {
+            self.len = slice.len();
+            self.content[..self.len].copy_from_slice(slice);
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
     pub fn from_hex(hex: &str) -> Self {
         let mut buffer = EdhocMessageBuffer::new();
         buffer.len = hex.len() / 2;
@@ -420,7 +430,7 @@ mod edhoc_parser {
                 if tail.len() > 0 {
                     // EAD value is present
                     let mut buffer = EdhocMessageBuffer::new();
-                    buffer.content[..tail.len()].copy_from_slice(tail);
+                    buffer.fill_with_slice(tail).unwrap(); // TODO(hax): this *should* not panic due to the buffer sizes passed from upstream functions. can we prove it with hax?
                     buffer.len = tail.len();
                     ead_value = Some(buffer);
                 }
@@ -529,9 +539,11 @@ mod edhoc_parser {
                 let mut g_y: BytesP256ElemLen = [0x00; P256_ELEM_LEN];
                 g_y.copy_from_slice(key);
                 if let Some(c2) = decoded.get(P256_ELEM_LEN..) {
-                    ciphertext_2.len = c2.len(); // len - gy_len - 2
-                    ciphertext_2.content[..ciphertext_2.len].copy_from_slice(c2);
-                    Ok((g_y, ciphertext_2))
+                    if ciphertext_2.fill_with_slice(c2).is_ok() {
+                        Ok((g_y, ciphertext_2))
+                    } else {
+                        Err(EDHOCError::ParsingError)
+                    }
                 } else {
                     Err(EDHOCError::ParsingError)
                 }

--- a/crypto/edhoc-crypto-psa/src/lib.rs
+++ b/crypto/edhoc-crypto-psa/src/lib.rs
@@ -116,7 +116,7 @@ impl CryptoTrait for Crypto {
             alg,
             iv,
             ad,
-            &plaintext.content[..plaintext.len],
+            plaintext.as_slice(),
             &mut output_buffer.content,
         )
         .unwrap();
@@ -158,7 +158,7 @@ impl CryptoTrait for Crypto {
             alg,
             iv,
             ad,
-            &ciphertext.content[..ciphertext.len],
+            &ciphertext.as_slice(),
             &mut output_buffer.content,
         ) {
             Ok(_) => {

--- a/crypto/edhoc-crypto-rustcrypto/src/lib.rs
+++ b/crypto/edhoc-crypto-rustcrypto/src/lib.rs
@@ -75,7 +75,7 @@ impl<Rng: rand_core::RngCore + rand_core::CryptoRng> CryptoTrait for Crypto<Rng>
     ) -> BufferCiphertext3 {
         let key = AesCcm16_64_128::new(key.into());
         let mut outbuffer = BufferCiphertext3::new();
-        outbuffer.content[..plaintext.len].copy_from_slice(&plaintext.content[..plaintext.len]);
+        outbuffer.content[..plaintext.len].copy_from_slice(plaintext.as_slice());
         if let Ok(tag) =
             key.encrypt_in_place_detached(iv.into(), ad, &mut outbuffer.content[..plaintext.len])
         {

--- a/ead/edhoc-ead-zeroconf/src/lib.rs
+++ b/ead/edhoc-ead-zeroconf/src/lib.rs
@@ -168,7 +168,7 @@ fn build_enc_id<Crypto: CryptoTrait>(
     // plaintext = (ID_U: bstr)
     let mut plaintext = EdhocMessageBuffer::new();
     plaintext.content[0] = CBOR_MAJOR_BYTE_STRING + id_u.len as u8;
-    plaintext.content[1..1 + id_u.len].copy_from_slice(&id_u.content[..id_u.len]);
+    plaintext.content[1..1 + id_u.len].copy_from_slice(id_u.as_slice());
     plaintext.len = 1 + id_u.len;
 
     // external_aad = (SS: int)
@@ -271,11 +271,10 @@ fn encode_ead_1_value(
 
     output.content[2] = CBOR_TEXT_STRING;
     output.content[3] = loc_w.len as u8;
-    output.content[4..4 + loc_w.len].copy_from_slice(&loc_w.content[..loc_w.len]);
+    output.content[4..4 + loc_w.len].copy_from_slice(loc_w.as_slice());
 
     output.content[4 + loc_w.len] = CBOR_MAJOR_BYTE_STRING + enc_id.len as u8;
-    output.content[5 + loc_w.len..5 + loc_w.len + enc_id.len]
-        .copy_from_slice(&enc_id.content[..enc_id.len]);
+    output.content[5 + loc_w.len..5 + loc_w.len + enc_id.len].copy_from_slice(enc_id.as_slice());
 
     output.len = 5 + loc_w.len + enc_id.len;
     output.content[1] = (output.len - 2) as u8;
@@ -492,7 +491,7 @@ pub fn encode_voucher_request(
 
     output.content[1] = CBOR_BYTE_STRING;
     output.content[2] = message_1.len as u8;
-    output.content[3..3 + message_1.len].copy_from_slice(&message_1.content[..message_1.len]);
+    output.content[3..3 + message_1.len].copy_from_slice(message_1.as_slice());
 
     if let Some(opaque_state) = opaque_state {
         output.content[0] = CBOR_MAJOR_ARRAY | 2;
@@ -500,7 +499,7 @@ pub fn encode_voucher_request(
         output.content[3 + message_1.len] = CBOR_BYTE_STRING;
         output.content[4 + message_1.len] = opaque_state.len as u8;
         output.content[5 + message_1.len..5 + message_1.len + opaque_state.len]
-            .copy_from_slice(&opaque_state.content[..opaque_state.len]);
+            .copy_from_slice(opaque_state.as_slice());
 
         output.len = 5 + message_1.len + opaque_state.len;
     } else {
@@ -575,7 +574,7 @@ fn handle_voucher_request<Crypto: CryptoTrait>(
 
     // compute hash
     let mut message_1_buf: BytesMaxBuffer = [0x00; MAX_BUFFER_LEN];
-    message_1_buf[..message_1.len].copy_from_slice(&message_1.content[..message_1.len]);
+    message_1_buf[..message_1.len].copy_from_slice(message_1.as_slice());
     let h_message_1 = crypto.sha256_digest(&message_1_buf, message_1.len);
 
     let prk = compute_prk(crypto, w, g_x);
@@ -648,7 +647,7 @@ fn encode_voucher_input(
     voucher_input.content[2 + SHA256_DIGEST_LEN] = CBOR_BYTE_STRING;
     voucher_input.content[3 + SHA256_DIGEST_LEN] = cred_v.len as u8;
     voucher_input.content[4 + SHA256_DIGEST_LEN..4 + SHA256_DIGEST_LEN + cred_v.len]
-        .copy_from_slice(&cred_v.content[..cred_v.len]);
+        .copy_from_slice(cred_v.as_slice());
 
     voucher_input.len = 4 + SHA256_DIGEST_LEN + cred_v.len;
 
@@ -663,7 +662,7 @@ fn compute_voucher_mac<Crypto: CryptoTrait>(
     let mut voucher_mac: BytesMac = [0x00; MAC_LENGTH];
 
     let mut context = [0x00; MAX_KDF_CONTEXT_LEN];
-    context[..voucher_input.len].copy_from_slice(&voucher_input.content[..voucher_input.len]);
+    context[..voucher_input.len].copy_from_slice(voucher_input.as_slice());
 
     let voucher_mac_buf = edhoc_kdf_expand(crypto, prk, 2, &context, voucher_input.len, MAC_LENGTH);
     voucher_mac[..MAC_LENGTH].copy_from_slice(&voucher_mac_buf[..MAC_LENGTH]);
@@ -688,7 +687,7 @@ fn encode_voucher_response(
 
     output.content[1] = CBOR_BYTE_STRING;
     output.content[2] = message_1.len as u8;
-    output.content[3..3 + message_1.len].copy_from_slice(&message_1.content[..message_1.len]);
+    output.content[3..3 + message_1.len].copy_from_slice(message_1.as_slice());
 
     output.content[3 + message_1.len] = CBOR_MAJOR_BYTE_STRING + ENCODED_VOUCHER_LEN as u8;
     output.content[4 + message_1.len..4 + message_1.len + ENCODED_VOUCHER_LEN]
@@ -701,7 +700,7 @@ fn encode_voucher_response(
         output.content[5 + message_1.len + ENCODED_VOUCHER_LEN] = opaque_state.len as u8;
         output.content[6 + message_1.len + ENCODED_VOUCHER_LEN
             ..6 + message_1.len + ENCODED_VOUCHER_LEN + opaque_state.len]
-            .copy_from_slice(&opaque_state.content[..opaque_state.len]);
+            .copy_from_slice(opaque_state.as_slice());
 
         output.len = 6 + message_1.len + ENCODED_VOUCHER_LEN + opaque_state.len;
     } else {

--- a/examples/coap/src/bin/coapclient.rs
+++ b/examples/coap/src/bin/coapclient.rs
@@ -33,7 +33,7 @@ fn main() {
     let mut msg_1_buf = Vec::from([0xf5u8]); // EDHOC message_1 when transported over CoAP is prepended with CBOR true
     let c_i = generate_connection_identifier_cbor(&mut edhoc_crypto::default_crypto());
     let (initiator, message_1) = initiator.prepare_message_1(c_i).unwrap();
-    msg_1_buf.extend_from_slice(&message_1.content[..message_1.len]);
+    msg_1_buf.extend_from_slice(message_1.as_slice());
     println!("message_1 len = {}", msg_1_buf.len());
 
     let response = CoAPClient::post_with_timeout(url, msg_1_buf, timeout).unwrap();
@@ -52,7 +52,7 @@ fn main() {
     if let Ok((initiator, c_r)) = m2result {
         let mut msg_3 = Vec::from([c_r]);
         let (mut initiator, message_3, prk_out) = initiator.prepare_message_3().unwrap();
-        msg_3.extend_from_slice(&message_3.content[..message_3.len]);
+        msg_3.extend_from_slice(message_3.as_slice());
         println!("message_3 len = {}", msg_3.len());
 
         let _response = CoAPClient::post_with_timeout(url, msg_3, timeout).unwrap();

--- a/examples/coap/src/bin/coapserver-coaphandler.rs
+++ b/examples/coap/src/bin/coapserver-coaphandler.rs
@@ -132,7 +132,7 @@ impl coap_handler::Handler for EdhocHandler {
             EdhocResponse::OkSend2 { c_r, responder } => {
                 let (responder, message_2) = responder.prepare_message_2(c_r).unwrap();
                 self.connections.push((c_r, responder));
-                response.set_payload(&message_2.content[..message_2.len]);
+                response.set_payload(message_2.as_slice());
             }
             EdhocResponse::Message3Processed => (), // "send empty ack back"?
         };

--- a/examples/coap/src/bin/coapserver.rs
+++ b/examples/coap/src/bin/coapserver.rs
@@ -50,7 +50,7 @@ fn main() {
                     let c_r =
                         generate_connection_identifier_cbor(&mut edhoc_crypto::default_crypto());
                     let (responder, message_2) = responder.prepare_message_2(c_r).unwrap();
-                    response.message.payload = Vec::from(&message_2.content[..message_2.len]);
+                    response.message.payload = Vec::from(message_2.as_slice());
                     // save edhoc connection
                     edhoc_connections.push((c_r, responder));
                 }

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -97,8 +97,7 @@ pub fn r_process_message_1(
                 if ead_success {
                     // hash message_1 and save the hash to the state to avoid saving the whole message
                     let mut message_1_buf: BytesMaxBuffer = [0x00; MAX_BUFFER_LEN];
-                    message_1_buf[..message_1.len]
-                        .copy_from_slice(&message_1.content[..message_1.len]);
+                    message_1_buf[..message_1.len].copy_from_slice(message_1.as_slice());
                     let h_message_1 = crypto.sha256_digest(&message_1_buf, message_1.len);
 
                     let state = State(
@@ -180,11 +179,11 @@ pub fn r_prepare_message_2(
 
     let mut ct: BufferCiphertext2 = BufferCiphertext2::new();
     ct.len = plaintext_2.len;
-    ct.content[..ct.len].copy_from_slice(&plaintext_2.content[..ct.len]);
+    ct.content[..ct.len].copy_from_slice(plaintext_2.as_slice());
 
     let ciphertext_2 = encrypt_decrypt_ciphertext_2(crypto, &prk_2e, &th_2, ct);
 
-    ct.content[..ct.len].copy_from_slice(&ciphertext_2.content[..ciphertext_2.len]);
+    ct.content[..ct.len].copy_from_slice(ciphertext_2.as_slice());
 
     let message_2 = encode_message_2(&g_y, &ct);
 
@@ -371,7 +370,7 @@ pub fn i_prepare_message_1(
     );
 
     let mut message_1_buf: BytesMaxBuffer = [0x00; MAX_BUFFER_LEN];
-    message_1_buf[..message_1.len].copy_from_slice(&message_1.content[..message_1.len]);
+    message_1_buf[..message_1.len].copy_from_slice(message_1.as_slice());
 
     // hash message_1 here to avoid saving the whole message in the state
     let h_message_1 = crypto.sha256_digest(&message_1_buf, message_1.len);
@@ -651,8 +650,7 @@ fn encode_ead_item(ead_1: &EADItem) -> EdhocMessageBuffer {
 
     // encode value
     if let Some(ead_1_value) = &ead_1.value {
-        output.content[1..1 + ead_1_value.len]
-            .copy_from_slice(&ead_1_value.content[..ead_1_value.len]);
+        output.content[1..1 + ead_1_value.len].copy_from_slice(ead_1_value.as_slice());
         output.len += ead_1_value.len;
     }
 
@@ -707,8 +705,7 @@ fn encode_message_1(
 
     if let Some(ead_1) = ead_1 {
         let ead_1 = encode_ead_item(ead_1);
-        output.content[output.len..output.len + ead_1.len]
-            .copy_from_slice(&ead_1.content[..ead_1.len]);
+        output.content[output.len..output.len + ead_1.len].copy_from_slice(ead_1.as_slice());
         output.len += ead_1.len;
     }
 
@@ -722,7 +719,7 @@ fn encode_message_2(g_y: &BytesP256ElemLen, ciphertext_2: &BufferCiphertext2) ->
     output.content[1] = P256_ELEM_LEN as u8 + ciphertext_2.len as u8;
     output.content[2..2 + P256_ELEM_LEN].copy_from_slice(&g_y[..]);
     output.content[2 + P256_ELEM_LEN..2 + P256_ELEM_LEN + ciphertext_2.len]
-        .copy_from_slice(&ciphertext_2.content[..ciphertext_2.len]);
+        .copy_from_slice(ciphertext_2.as_slice());
 
     output.len = 2 + P256_ELEM_LEN + ciphertext_2.len;
     output
@@ -761,7 +758,7 @@ fn compute_th_3(
     message[1] = th_2.len() as u8;
     message[2..2 + th_2.len()].copy_from_slice(&th_2[..]);
     message[2 + th_2.len()..2 + th_2.len() + plaintext_2.len]
-        .copy_from_slice(&plaintext_2.content[..plaintext_2.len]);
+        .copy_from_slice(plaintext_2.as_slice());
     message[2 + th_2.len() + plaintext_2.len..2 + th_2.len() + plaintext_2.len + cred_r.len()]
         .copy_from_slice(cred_r);
 
@@ -782,7 +779,7 @@ fn compute_th_4(
     message[1] = th_3.len() as u8;
     message[2..2 + th_3.len()].copy_from_slice(&th_3[..]);
     message[2 + th_3.len()..2 + th_3.len() + plaintext_3.len]
-        .copy_from_slice(&plaintext_3.content[..plaintext_3.len]);
+        .copy_from_slice(plaintext_3.as_slice());
     message[2 + th_3.len() + plaintext_3.len..2 + th_3.len() + plaintext_3.len + cred_i.len()]
         .copy_from_slice(cred_i);
 
@@ -821,7 +818,7 @@ fn encode_plaintext_3(
     if let Some(ead_3) = ead_3 {
         let ead_3 = encode_ead_item(ead_3);
         plaintext_3.content[plaintext_3.len..plaintext_3.len + ead_3.len]
-            .copy_from_slice(&ead_3.content[..ead_3.len]);
+            .copy_from_slice(ead_3.as_slice());
         plaintext_3.len += ead_3.len;
     }
 
@@ -897,7 +894,7 @@ fn encrypt_message_3(
 
     let ciphertext_3 = crypto.aes_ccm_encrypt_tag_8(&k_3, &iv_3, &enc_structure[..], plaintext_3);
 
-    output.content[1..output.len].copy_from_slice(&ciphertext_3.content[..ciphertext_3.len]);
+    output.content[1..output.len].copy_from_slice(ciphertext_3.as_slice());
 
     output
 }
@@ -924,7 +921,7 @@ fn decrypt_message_3(
     let p3 = crypto.aes_ccm_decrypt_tag_8(&k_3, &iv_3, &enc_structure, &ciphertext_3);
 
     if let Ok(p3) = p3 {
-        plaintext_3.content[..p3.len].copy_from_slice(&p3.content[..p3.len]);
+        plaintext_3.content[..p3.len].copy_from_slice(p3.as_slice());
         plaintext_3.len = p3.len;
 
         Ok(plaintext_3)
@@ -1034,7 +1031,7 @@ fn encode_plaintext_2(
     if let Some(ead_2) = ead_2 {
         let ead_2 = encode_ead_item(ead_2);
         plaintext_2.content[plaintext_2.len..plaintext_2.len + ead_2.len]
-            .copy_from_slice(&ead_2.content[..ead_2.len]);
+            .copy_from_slice(ead_2.as_slice());
         plaintext_2.len += ead_2.len;
     }
 

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -178,12 +178,11 @@ pub fn r_prepare_message_2(
     let th_3 = compute_th_3(crypto, &th_2, &plaintext_2, cred_r);
 
     let mut ct: BufferCiphertext2 = BufferCiphertext2::new();
-    ct.len = plaintext_2.len;
-    ct.content[..ct.len].copy_from_slice(plaintext_2.as_slice());
+    ct.fill_with_slice(plaintext_2.as_slice()).unwrap(); // TODO(hax): can we prove with hax that this won't panic since they use the same underlying buffer length?
 
     let ciphertext_2 = encrypt_decrypt_ciphertext_2(crypto, &prk_2e, &th_2, ct);
 
-    ct.content[..ct.len].copy_from_slice(ciphertext_2.as_slice());
+    ct.fill_with_slice(ciphertext_2.as_slice()).unwrap(); // TODO(hax): same as just above.
 
     let message_2 = encode_message_2(&g_y, &ct);
 


### PR DESCRIPTION
- [x] use `.as_slice()` instead of `buffer.content[..buffer.len]`
- [x] use `fill_with_slice(slice)` instead of `buffer[..buffer.len].copy_from_slice(slice)`

This introduces some unwrap calls which should not fail, and I hope it could be guaranteed by hax. If not then it can be reworked.

Deliberately not being exhaustive in the calls to `.content[]` within parsing routines. In this case, we also expect to have proofs from hax.