### PR TITLE
refactor: Apply fixes where clippy complains

### DIFF
--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -220,8 +220,8 @@ impl TryInto<EdhocMessageBuffer> for &[u8] {
 
     fn try_into(self) -> Result<EdhocMessageBuffer, Self::Error> {
         let mut buffer = [0u8; MAX_MESSAGE_SIZE_LEN];
-        if let Some(destination) = buffer.get_mut(..self.len()) {
-            destination.copy_from_slice(self);
+        if self.len() <= buffer.len() {
+            buffer[..self.len()].copy_from_slice(self);
 
             Ok(EdhocMessageBuffer {
                 content: buffer,

--- a/consts/src/lib.rs
+++ b/consts/src/lib.rs
@@ -219,11 +219,9 @@ impl TryInto<EdhocMessageBuffer> for &[u8] {
     type Error = ();
 
     fn try_into(self) -> Result<EdhocMessageBuffer, Self::Error> {
-        if self.len() <= MAX_MESSAGE_SIZE_LEN {
-            let mut buffer = [0u8; MAX_MESSAGE_SIZE_LEN];
-            for i in 0..self.len() {
-                buffer[i] = self[i];
-            }
+        let mut buffer = [0u8; MAX_MESSAGE_SIZE_LEN];
+        if let Some(destination) = buffer.get_mut(..self.len()) {
+            destination.copy_from_slice(self);
 
             Ok(EdhocMessageBuffer {
                 content: buffer,
@@ -460,9 +458,9 @@ mod edhoc_parser {
             {
                 // NOTE: arrays must be at least 2 items long, otherwise the compact encoding (int) must be used
                 suites_i_len = decoder.array()?;
-                if suites_i_len <= suites_i.len() {
-                    for i in 0..suites_i_len {
-                        suites_i[i] = decoder.u8()?;
+                if let Some(suites_i_used) = suites_i.get_mut(..suites_i_len) {
+                    for s in suites_i_used.iter_mut() {
+                        *s = decoder.u8()?;
                     }
                     Ok((suites_i, suites_i_len, decoder))
                 } else {
@@ -553,7 +551,6 @@ mod edhoc_parser {
     pub fn decode_plaintext_2(
         plaintext_2: &BufferCiphertext2,
     ) -> Result<(u8, IdCred, BytesMac2, Option<EADItem>), EDHOCError> {
-        let id_cred_r: IdCred;
         let mut mac_2: BytesMac2 = [0x00; MAC_LENGTH_2];
 
         let mut decoder = CBORDecoder::new(plaintext_2.as_slice());
@@ -561,13 +558,13 @@ mod edhoc_parser {
         let c_r = decoder.int_raw()?;
 
         // NOTE: if len of bstr is 1, it is a compact kid and therefore should have been encoded as int
-        if CBOR_MAJOR_BYTE_STRING == CBORDecoder::type_of(decoder.current()?)
+        let id_cred_r = if CBOR_MAJOR_BYTE_STRING == CBORDecoder::type_of(decoder.current()?)
             && CBORDecoder::info_of(decoder.current()?) > 1
         {
-            id_cred_r = IdCred::FullCredential(decoder.bytes()?);
+            IdCred::FullCredential(decoder.bytes()?)
         } else {
-            id_cred_r = IdCred::CompactKid(decoder.int_raw()?);
-        }
+            IdCred::CompactKid(decoder.int_raw()?)
+        };
 
         mac_2[..].copy_from_slice(decoder.bytes_sized(MAC_LENGTH_2)?);
 
@@ -591,18 +588,17 @@ mod edhoc_parser {
         plaintext_3: &BufferPlaintext3,
     ) -> Result<(IdCred, BytesMac3, Option<EADItem>), EDHOCError> {
         let mut mac_3: BytesMac3 = [0x00; MAC_LENGTH_3];
-        let id_cred_i: IdCred;
 
         let mut decoder = CBORDecoder::new(plaintext_3.as_slice());
 
         // NOTE: if len of bstr is 1, then it is a compact kid and therefore should have been encoded as int
-        if CBOR_MAJOR_BYTE_STRING == CBORDecoder::type_of(decoder.current()?)
+        let id_cred_i = if CBOR_MAJOR_BYTE_STRING == CBORDecoder::type_of(decoder.current()?)
             && CBORDecoder::info_of(decoder.current()?) > 1
         {
-            id_cred_i = IdCred::FullCredential(decoder.bytes()?);
+            IdCred::FullCredential(decoder.bytes()?)
         } else {
-            id_cred_i = IdCred::CompactKid(decoder.int_raw()?);
-        }
+            IdCred::CompactKid(decoder.int_raw()?)
+        };
 
         mac_3[..].copy_from_slice(decoder.bytes_sized(MAC_LENGTH_3)?);
 

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -683,13 +683,13 @@ fn encode_message_1(
         // several suites, will be encoded as an array
         output.content[1] = CBOR_MAJOR_ARRAY + (suites_len as u8);
         raw_suites_len += 1;
-        for i in 0..suites_len {
-            if suites[i] <= CBOR_UINT_1BYTE {
-                output.content[1 + raw_suites_len] = suites[i];
+        for &suite in suites[0..suites_len].iter() {
+            if suite <= CBOR_UINT_1BYTE {
+                output.content[1 + raw_suites_len] = suite;
                 raw_suites_len += 1;
             } else {
                 output.content[1 + raw_suites_len] = CBOR_UINT_1BYTE;
-                output.content[2 + raw_suites_len] = suites[i];
+                output.content[2 + raw_suites_len] = suite;
                 raw_suites_len += 2;
             }
         }

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -898,8 +898,6 @@ fn decrypt_message_3(
     th_3: &BytesHashLen,
     message_3: &BufferMessage3,
 ) -> Result<BufferPlaintext3, EDHOCError> {
-    let mut plaintext_3: BufferPlaintext3 = BufferPlaintext3::new();
-
     // decode message_3
     let len = (message_3.content[0usize] ^ CBOR_MAJOR_BYTE_STRING) as usize;
 
@@ -911,16 +909,7 @@ fn decrypt_message_3(
 
     let enc_structure = encode_enc_structure(th_3);
 
-    let p3 = crypto.aes_ccm_decrypt_tag_8(&k_3, &iv_3, &enc_structure, &ciphertext_3);
-
-    if let Ok(p3) = p3 {
-        plaintext_3.content[..p3.len].copy_from_slice(p3.as_slice());
-        plaintext_3.len = p3.len;
-
-        Ok(plaintext_3)
-    } else {
-        Err(p3.unwrap_err())
-    }
+    crypto.aes_ccm_decrypt_tag_8(&k_3, &iv_3, &enc_structure, &ciphertext_3)
 }
 
 // output must hold id_cred.len() + cred.len()

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -115,7 +115,7 @@ impl<'a, Crypto: CryptoTrait> EdhocResponderBuildM2<'a, Crypto> {
         match r_prepare_message_2(
             self.state,
             &mut self.crypto,
-            &self.cred_r,
+            self.cred_r,
             self.r.try_into().expect("Wrong length of private key"),
             y,
             g_y,
@@ -322,7 +322,7 @@ pub fn generate_connection_identifier_cbor<Crypto: CryptoTrait>(crypto: &mut Cry
         c_i as u8 // verbatim encoding of single byte integer
     } else if c_i < 0 && c_i >= -24 {
         // negative single byte integer encoding
-        CBOR_NEG_INT_1BYTE_START - 1 + (c_i.abs() as u8)
+        CBOR_NEG_INT_1BYTE_START - 1 + c_i.unsigned_abs()
     } else {
         0
     }


### PR DESCRIPTION
This contains some automatically applied and some manual changes.

For the manual changes, the "use map instead of" commit is a test balloon for the translation of more functional style programming. A previous iteration in #151 did not work -- but there, a mut was (needlessly -- that part was not refactored to see what hacspec can do) accessed from the map closure while living in the outer function.

Replaces: https://github.com/openwsn-berkeley/edhoc-rs/pull/151