### PR TITLE
Trying to use vanilla psa wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,4 +61,4 @@ hacspec-hkdf = { git = "https://github.com/malishav/hacspec", branch = "aesccm" 
 hacspec-sha256 = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
 hacspec-aes = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
 hacspec-aes-ccm = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
-psa-crypto = { git = "https://github.com/malishav/rust-psa-crypto", branch = "baremetal" }
+psa-crypto = { git = "https://github.com/geonnave/rust-psa-crypto", branch = "have-no-std-and-baremetal-features" }

--- a/crypto/edhoc-crypto-psa/Cargo.toml
+++ b/crypto/edhoc-crypto-psa/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 [dependencies]
 edhoc-consts.workspace = true
 psa-crypto = { version = "0.9.2" }
+p256 = { version = "0.13.2", default-features = false, features = [ "ecdh" ] }
 
 [features]
 baremetal = [ "psa-crypto/baremetal" ]

--- a/crypto/edhoc-crypto-psa/Cargo.toml
+++ b/crypto/edhoc-crypto-psa/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 edhoc-consts.workspace = true
-psa-crypto = { version = "0.9.2" }
+psa-crypto = { version = "0.12.0" }
 p256 = { version = "0.13.2", default-features = false, features = [ "ecdh" ] }
 
 [features]


### PR DESCRIPTION
The approach is twofold:
1. Avoid depending on point compression on psa side, since [the PSA API](https://arm-software.github.io/psa-api/crypto/1.1/IHI0086-PSA_Certified_Crypto_API-1.1.2.pdf) seems to not support compressed points.
2. Use a [newly patched crypto-psa](https://github.com/geonnave/rust-psa-crypto/tree/have-no-std-and-baremetal-features) that only has patches for `no-std` and `baremetal` features (no patches at the `mbedtls` level). I hope to be able to merge that upstream, so that we can use the vanilla psa wrapper.

Reasoning behind this PR:
- PSA seems to be getting popular, as per [recent adoption in RIOT](https://github.com/RIOT-OS/RIOT/releases/tag/2023.10) and also its presence in the cc312 sdk. I think it is good if we have an unpatched backend based on it. Right now this comes at the cost of providing our own implementations of `extract` and `expand`, and manually decompressing public keys using a third party library.
- Simplify publication at crates.io.
- Have a baremetal, software-based, fully functional crypto backend (`rustcrypto` seems to depend on RIOT for the RNG).