### PR TITLE
Rename to `lakers`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Run unit tests with default features
       run: RUST_BACKTRACE=1 cargo test
 
-    - name: Run unit tests with feature matrix # note that we only add `--package edhoc-ead-zeroconf` when testing with that config
-      run: RUST_BACKTRACE=1 cargo test -p edhoc-rs -p edhoc-crypto -p edhoc-consts ${{ matrix.ead == 'ead-zeroconf' && '-p edhoc-ead-zeroconf' || '' }}  --no-default-features --features="${{ matrix.crypto_backend }}, ${{ matrix.ead }}" --no-fail-fast -- --test-threads 1
+    - name: Run unit tests with feature matrix # note that we only add `--package lakers-ead-zeroconf` when testing with that config
+      run: RUST_BACKTRACE=1 cargo test -p lakers -p edhoc-crypto -p lakers-shared ${{ matrix.ead == 'ead-zeroconf' && '-p lakers-ead-zeroconf' || '' }}  --no-default-features --features="${{ matrix.crypto_backend }}, ${{ matrix.ead }}" --no-fail-fast -- --test-threads 1
 
 
   build-edhoc-package:
@@ -62,7 +62,7 @@ jobs:
       run: sudo apt-get -y update && sudo apt-get -y install gcc-arm-none-eabi
 
     - name: Build
-      run: cargo build --package edhoc-rs --package edhoc-crypto --package edhoc-ead --no-default-features --features="${{ matrix.crypto_backend }}, ${{ matrix.ead }}" --release
+      run: cargo build --package lakers --package edhoc-crypto --package lakers-ead-dispatch --no-default-features --features="${{ matrix.crypto_backend }}, ${{ matrix.ead }}" --release
 
 
   generate-fstar:
@@ -70,28 +70,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout edhoc-rs
+    - name: Checkout lakers
       uses: actions/checkout@v3
 
-    - name: Generate fstar code over edhoc-rs and edhoc-consts
+    - name: Generate fstar code over lakers and lakers-shared
       run: |
-        docker run --rm -v ${{ github.workspace }}:/edhoc-rs docker.io/geonnave/hax bash -e -c "
-        cd edhoc-rs
+        docker run --rm -v ${{ github.workspace }}:/lakers docker.io/geonnave/hax bash -e -c "
+        cd lakers
 
         # generate the fstar files
-        cargo-hax -C -p edhoc-rs --no-default-features --features='edhoc-crypto/hacspec, ead-none' --release \; into -i '-edhoc_rs::generate_connection_identifier_cbor -edhoc_rs::generate_connection_identifier' fstar
-        cargo-hax -C -p edhoc-consts \; into fstar
+        cargo-hax -C -p lakers --no-default-features --features='edhoc-crypto/hacspec, ead-none' --release \; into -i '-lakers::generate_connection_identifier_cbor -lakers::generate_connection_identifier' fstar
+        cargo-hax -C -p lakers-shared \; into fstar
 
         # even if fstar generation was ok, fail if something is not implemented
         [ -z "$(find -name *.fst -type f | xargs grep 'something is not implemented yet')" ]
         "
-        zip -j -r edhoc-rs-fstar.zip $(find . -name *fst)
+        zip -j -r lakers-fstar.zip $(find . -name *fst)
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:
         name: fstar-code
-        path: ./edhoc-rs-fstar.zip
+        path: ./lakers-fstar.zip
 
 
   build-static-lib-and-headers:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,19 +40,19 @@ license = "BSD-3-Clause"
 
 [workspace.dependencies]
 
-edhoc-consts = { path = "consts/", version = "^0.4.0-alpha.1" }
-edhoc-ead = { path = "ead/", version = "^0.4.0-alpha.1", default-features = false }
-edhoc-ead-none = { path = "ead/edhoc-ead-none/", version = "^0.4.0-alpha.1" }
-edhoc-ead-zeroconf = { path = "ead/edhoc-ead-zeroconf/", version = "^0.4.0-alpha.1" }
+edhoc-consts = { package = "lakers-shared", path = "consts/", version = "^0.4.0-alpha.1" }
+edhoc-ead = { package = "lakers-ead-dispatch", path = "ead/", version = "^0.4.0-alpha.1", default-features = false }
+edhoc-ead-none = { package = "lakers-ead-none", path = "ead/edhoc-ead-none/", version = "^0.4.0-alpha.1" }
+edhoc-ead-zeroconf = { package = "lakers-ead-zeroconf", path = "ead/edhoc-ead-zeroconf/", version = "^0.4.0-alpha.1" }
 edhoc-crypto = { path = "crypto/", version = "^0.4.0-alpha.1" }
 
 edhoc-crypto-cc2538 = { path = "crypto/edhoc-crypto-cc2538/", version = "^0.4.0-alpha.1" }
 edhoc-crypto-cryptocell310 = { path = "crypto/edhoc-crypto-cryptocell310-sys/", version = "^0.4.0-alpha.1" }
 edhoc-crypto-hacspec = { path = "crypto/edhoc-crypto-hacspec/", version = "^0.4.0-alpha.1" }
 edhoc-crypto-psa = { path = "crypto/edhoc-crypto-psa/", version = "^0.4.0-alpha.1" }
-edhoc-crypto-rustcrypto = { path = "crypto/edhoc-crypto-rustcrypto/", version = "^0.4.0-alpha.1" }
+edhoc-crypto-rustcrypto = { package = "lakers-crypto-rustcrypto", path = "crypto/edhoc-crypto-rustcrypto/", version = "^0.4.0-alpha.1" }
 
-edhoc-rs = { path = "lib/", version = "^0.4.0-alpha.1", default-features = false }
+edhoc-rs = { package = "lakers", path = "lib/", version = "^0.4.0-alpha.1", default-features = false }
 
 [patch.crates-io]
 hacspec-lib = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# edhoc-rs
+# lakers: EDHOC implemented in Rust
 
 [![Build and test](https://github.com/openwsn-berkeley/edhoc-rs/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/openwsn-berkeley/edhoc-rs/actions/workflows/build-and-test.yml)
 

--- a/consts/Cargo.toml
+++ b/consts/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "edhoc-consts"
+name = "lakers-shared"
 version.workspace = true
 edition = "2021"
 authors = ["Mališa Vučinić <malisa.vucinic@inria.fr>"]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -8,7 +8,7 @@ description = "EDHOC crypto library dispatch crate"
 repository.workspace = true
 
 [dependencies]
-edhoc-consts = { path = "../consts", default-features = false }
+edhoc-consts = { package = "lakers-shared", path = "../consts", default-features = false }
 
 # hacspec
 edhoc-crypto-hacspec = { workspace = true, optional = true }

--- a/crypto/edhoc-crypto-rustcrypto/Cargo.toml
+++ b/crypto/edhoc-crypto-rustcrypto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "edhoc-crypto-rustcrypto"
+name = "lakers-crypto-rustcrypto"
 version.workspace = true
 edition = "2021"
 authors = [ "Christian Amsüss <chrysn@fsfe.org>" ]

--- a/ead/Cargo.toml
+++ b/ead/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "edhoc-ead"
+name = "lakers-ead-dispatch"
 version.workspace = true
 edition = "2021"
 authors = ["Geovane Fedrecheski <geonnave@gmail.com>"]

--- a/ead/edhoc-ead-none/Cargo.toml
+++ b/ead/edhoc-ead-none/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "edhoc-ead-none"
+name = "lakers-ead-none"
 version.workspace = true
 edition = "2021"
 authors = ["Geovane Fedrecheski <geonnave@gmail.com>"]

--- a/ead/edhoc-ead-zeroconf/Cargo.toml
+++ b/ead/edhoc-ead-zeroconf/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "edhoc-ead-zeroconf"
+name = "lakers-ead-zeroconf"
 version.workspace = true
 edition = "2021"
 authors = ["Geovane Fedrecheski <geonnave@gmail.com>"]

--- a/examples/coap/Cargo.toml
+++ b/examples/coap/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-edhoc-rs = { path = "../../lib" }
+edhoc-rs = { package = "lakers", path = "../../lib" }
 edhoc-crypto = { path = "../../crypto/", features = [ "hacspec" ] }
 hexlit = "0.5.3"
 coap = { version = "0.13" }

--- a/examples/edhoc-rs-cc2538/Cargo.toml
+++ b/examples/edhoc-rs-cc2538/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 description = "edhoc-rs example on CC2538 SoC"
 
 [dependencies]
-edhoc-rs = { path = "../../lib", default-features = false }
+edhoc-rs = { package = "lakers", path = "../../lib", default-features = false }
 edhoc-crypto = { path = "../../crypto", default-features = false }
 # depend on an allocator
 embedded-alloc = "0.5.0"

--- a/examples/edhoc-rs-no_std/Cargo.toml
+++ b/examples/edhoc-rs-no_std/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-edhoc-rs = { path = "../../lib", default-features = false }
+edhoc-rs = { package = "lakers", path = "../../lib", default-features = false }
 edhoc-crypto = { path = "../../crypto", default-features = false }
 hexlit = "0.5.3"
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "edhoc-rs"
+name = "lakers"
 version.workspace = true
 edition = "2021"
 authors = ["Mališa Vučinić <malisa.vucinic@inria.fr>"]


### PR DESCRIPTION
Picking "lakers" as discussed in today's call with @malishav and @geonnave. This PR only renames the crates that'd actually go to crates.io, and uses 

* "edhoc-rs" => "lakers"
* "edhoc-consts" => "lakers-shared" (because it's not really constants any more; that's a pending rename anyway)
* "edhoc-crypto-rustcrypto" => "lakers-crypto-rustcrypto" (which so far is the only backend that doesn't need patching and can go up as a publicly usable reference)
* "edhoc-ead" => "lakers-ead-dispatch" (edhoc-crypto would be renamed to edhoc-crypto-dispatch too, because that's what they do)
* "edhoc-ead-none" => "lakers-ead-none"
* "edhoc-ead-zeroconf" => "lakers-ead-zeroconf"

All the renaming is for now purely local to the Cargo.toml files; inside Rust no identifiers are replaced. We'll probably want to do that at some point in time, but that's best done on a flag day when nobody has any pending PRs or (worse) local changes, as that's a big search-and-replace (and may make sense together with directory renaming etc).

I'll probably need one or two iterations on CI to fix mentions of names I haven't found in local testing.