### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,25 +34,25 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 repository = "https://github.com/openwsn-berkeley/edhoc-rs/"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
 
-lakers-shared = { package = "lakers-shared", path = "shared/", version = "^0.4.0" }
-lakers-ead = { package = "lakers-ead-dispatch", path = "ead/", version = "^0.4.0", default-features = false }
-lakers-ead-none = { package = "lakers-ead-none", path = "ead/lakers-ead-none/", version = "^0.4.0" }
-lakers-ead-zeroconf = { package = "lakers-ead-zeroconf", path = "ead/lakers-ead-zeroconf/", version = "^0.4.0" }
+lakers-shared = { package = "lakers-shared", path = "shared/", version = "^0.4.1" }
+lakers-ead = { package = "lakers-ead-dispatch", path = "ead/", version = "^0.4.1", default-features = false }
+lakers-ead-none = { package = "lakers-ead-none", path = "ead/lakers-ead-none/", version = "^0.4.1" }
+lakers-ead-zeroconf = { package = "lakers-ead-zeroconf", path = "ead/lakers-ead-zeroconf/", version = "^0.4.1" }
 lakers-crypto = { path = "crypto/" }
 
 lakers-crypto-cc2538 = { path = "crypto/lakers-crypto-cc2538/" }
 lakers-crypto-cryptocell310 = { path = "crypto/lakers-crypto-cryptocell310-sys/" }
 lakers-crypto-hacspec = { path = "crypto/lakers-crypto-hacspec/" }
 lakers-crypto-psa = { path = "crypto/lakers-crypto-psa/" }
-lakers-crypto-rustcrypto = { package = "lakers-crypto-rustcrypto", path = "crypto/lakers-crypto-rustcrypto/", version = "^0.4.0" }
+lakers-crypto-rustcrypto = { package = "lakers-crypto-rustcrypto", path = "crypto/lakers-crypto-rustcrypto/", version = "^0.4.1" }
 
-edhoc-rs = { package = "lakers", path = "lib/", version = "^0.4.0", default-features = false }
+edhoc-rs = { package = "lakers", path = "lib/", version = "^0.4.1", default-features = false }
 
 [patch.crates-io]
 hacspec-lib = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }


### PR DESCRIPTION
This minor bump is because there was a bug in the CI code for generating releases (fixed [here](https://github.com/openwsn-berkeley/edhoc-rs/commit/db0098f558a1c6747999fb64e46106ceb71d6b21)).